### PR TITLE
Add AUR repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ Website: https://johnfactotum.github.io/foliate/
 ### Flatpak
 <a href='https://flathub.org/apps/details/com.github.johnfactotum.Foliate'><img height='50' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
+### AUR
+If you're using an Arch-like Linux distro, you can find the package ```foliate``` in your AUR helper or do the following:
+```bash
+git clone https://aur.archlinux.org/foliate.git
+cd foliate
+makepkg -si
+```
+To install the Git version, find the package ```foliate-git``` in your AUR helper or do the following:
+```bash
+git clone https://aur.archlinux.org/foliate-git.git
+cd foliate
+makepkg -si
+```
+
 ### Install manually from source
 First, you'll need the following dependencies:
 - `gjs`


### PR DESCRIPTION
I've made a couple of AUR repos for the program. By the way, I added only ```i686``` and ```x86_64``` architectures there because I don't know whether it's gonna work on any kind of ARM procesors.