### PR TITLE
Update readme to include Void linux instructions

### DIFF
--- a/po/com.github.johnfactotum.Foliate.pot
+++ b/po/com.github.johnfactotum.Foliate.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.johnfactotum.Foliate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-30 05:06+0800\n"
+"POT-Creation-Date: 2019-06-01 11:19+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,8 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/com.github.johnfactotum.Foliate.desktop.in:3
-#: data/com.github.johnfactotum.Foliate.appdata.xml.in:6 src/main.js:1004
-#: src/main.js:1661
+#: data/com.github.johnfactotum.Foliate.appdata.xml.in:6 src/main.js:1014
+#: src/main.js:1733
 msgid "Foliate"
 msgstr ""
 
@@ -71,8 +71,8 @@ msgstr ""
 msgid "Bookmarks and annotations"
 msgstr ""
 
-#: data/com.github.johnfactotum.Foliate.appdata.xml.in:17 src/main.js:1335
-#: src/main.js:1626
+#: data/com.github.johnfactotum.Foliate.appdata.xml.in:17 src/main.js:1368
+#: src/main.js:1677
 msgid "Find in book"
 msgstr ""
 
@@ -152,186 +152,208 @@ msgstr ""
 msgid "Go back"
 msgstr ""
 
-#: src/main.js:684
+#: src/main.js:694
 msgid "No bookmarks"
 msgstr ""
 
-#: src/main.js:685
+#: src/main.js:695
 msgid "Add some bookmarks to see them here."
 msgstr ""
 
-#: src/main.js:721
+#: src/main.js:731
 msgid "Bookmark Current Location"
 msgstr ""
 
-#: src/main.js:726
+#: src/main.js:736
 msgid "Remove Current Location"
 msgstr ""
 
-#: src/main.js:743
+#: src/main.js:753
 msgid "No annotations"
 msgstr ""
 
-#: src/main.js:744
+#: src/main.js:754
 msgid "Highlight some text to add annotations."
 msgstr ""
 
-#: src/main.js:782 src/main.js:858
+#: src/main.js:792 src/main.js:868
 msgid "Copy"
 msgstr ""
 
-#: src/main.js:787
+#: src/main.js:797
 msgid "Highlight"
 msgstr ""
 
-#: src/main.js:796
+#: src/main.js:806
 msgid "Loading…"
 msgstr ""
 
-#: src/main.js:805
+#: src/main.js:815
 msgid "From Wiktionary, the free dictionary"
 msgstr ""
 
-#: src/main.js:843
+#: src/main.js:853
 msgid "View Full Definition"
 msgstr ""
 
-#: src/main.js:863
+#: src/main.js:873
 msgid "Remove"
 msgstr ""
 
-#: src/main.js:868
+#: src/main.js:878
 msgid "Note"
 msgstr ""
 
-#: src/main.js:943
+#: src/main.js:953
 msgid "Open some books to start reading"
 msgstr ""
 
-#: src/main.js:948
+#: src/main.js:958
 msgid "Open a file, or continue reading the last opened book."
 msgstr ""
 
-#: src/main.js:952
+#: src/main.js:962
 msgid "Open File…"
 msgstr ""
 
-#: src/main.js:956
+#: src/main.js:966
 msgid "Continue Reading"
 msgstr ""
 
-#: src/main.js:1075
+#: src/main.js:1087
 msgid "Oh no! The file cannot be opened"
 msgstr ""
 
-#: src/main.js:1322
+#: src/main.js:1355
 msgid "Table of contents"
 msgstr ""
 
-#: src/main.js:1348
+#: src/main.js:1381
 msgid "Set font, theme, and layout"
 msgstr ""
 
-#: src/main.js:1363
+#: src/main.js:1396
 msgid "Bookmarks"
 msgstr ""
 
-#: src/main.js:1377
+#: src/main.js:1410
 msgid "Annotations"
 msgstr ""
 
-#: src/main.js:1407
+#: src/main.js:1446
 msgid "Open…"
 msgstr ""
 
-#: src/main.js:1411
+#: src/main.js:1447
+msgid "Fullscreen"
+msgstr ""
+
+#: src/main.js:1451
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: src/main.js:1412
+#: src/main.js:1452
 msgid "About Foliate"
 msgstr ""
 
-#: src/main.js:1422 src/main.js:1442
+#: src/main.js:1479 src/main.js:1499
 msgid "About This Book"
 msgstr ""
 
-#: src/main.js:1505
+#: src/main.js:1562
 msgid "Publisher"
 msgstr ""
 
-#: src/main.js:1506
+#: src/main.js:1563
 msgid "Publication Date"
 msgstr ""
 
-#: src/main.js:1507
+#: src/main.js:1564
 msgid "Modified Date"
 msgstr ""
 
-#: src/main.js:1508
+#: src/main.js:1565
 msgid "Language"
 msgstr ""
 
-#: src/main.js:1509
+#: src/main.js:1566
 msgid "Copyright"
 msgstr ""
 
-#: src/main.js:1510
+#: src/main.js:1567
 msgid "Identifier"
 msgstr ""
 
-#: src/main.js:1583
+#: src/main.js:1640
 msgid "All files"
 msgstr ""
 
-#: src/main.js:1587
+#: src/main.js:1644
 msgid "EPUB files"
 msgstr ""
 
-#: src/main.js:1609
+#: src/main.js:1673
 msgid "General"
 msgstr ""
 
-#: src/main.js:1611
+#: src/main.js:1675
 msgid "Show table of contents"
 msgstr ""
 
-#: src/main.js:1612
+#: src/main.js:1676
 msgid "Show bookmarks"
 msgstr ""
 
-#: src/main.js:1613
+#: src/main.js:1678
 msgid "Show menu"
 msgstr ""
 
-#: src/main.js:1617
+#: src/main.js:1682
 msgid "Navigation"
 msgstr ""
 
-#: src/main.js:1619
+#. I can't find where to access the enums in GJS,
+#. so just use ints for now
+#: src/main.js:1684 src/main.js:1702
 msgid "Go to the next page"
 msgstr ""
 
-#: src/main.js:1620
+#: src/main.js:1685 src/main.js:1703
 msgid "Go to the previous page"
 msgstr ""
 
-#: src/main.js:1624
-msgid "Search"
+#: src/main.js:1686
+msgid "Go back to previous location"
 msgstr ""
 
-#: src/main.js:1630
+#: src/main.js:1690
 msgid "View"
 msgstr ""
 
-#: src/main.js:1632
+#: src/main.js:1692
 msgid "Increase font size"
 msgstr ""
 
-#: src/main.js:1633
+#: src/main.js:1693
 msgid "Decrease font size"
 msgstr ""
 
-#: src/main.js:1662
+#: src/main.js:1694
+msgid "Toggle fullscreen"
+msgstr ""
+
+#: src/main.js:1698
+msgid "Touchpad Gestures"
+msgstr ""
+
+#: src/main.js:1704
+msgid "Zoom in"
+msgstr ""
+
+#: src/main.js:1705
+msgid "Zoom out"
+msgstr ""
+
+#: src/main.js:1734
 msgid "A simple eBook viewer"
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.johnfactotum.Foliate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-30 05:06+0800\n"
+"POT-Creation-Date: 2019-06-01 11:19+0800\n"
 "PO-Revision-Date: 2019-05-28 15:45+0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,8 +17,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/com.github.johnfactotum.Foliate.desktop.in:3
-#: data/com.github.johnfactotum.Foliate.appdata.xml.in:6 src/main.js:1004
-#: src/main.js:1661
+#: data/com.github.johnfactotum.Foliate.appdata.xml.in:6 src/main.js:1014
+#: src/main.js:1733
 msgid "Foliate"
 msgstr ""
 
@@ -70,8 +70,8 @@ msgstr "有標示章節的閱讀進度滑桿"
 msgid "Bookmarks and annotations"
 msgstr "書籤與註解"
 
-#: data/com.github.johnfactotum.Foliate.appdata.xml.in:17 src/main.js:1335
-#: src/main.js:1626
+#: data/com.github.johnfactotum.Foliate.appdata.xml.in:17 src/main.js:1368
+#: src/main.js:1677
 msgid "Find in book"
 msgstr "搜尋書籍內容"
 
@@ -85,11 +85,11 @@ msgstr ""
 
 #: data/com.github.johnfactotum.Foliate.appdata.xml.in:47
 msgid "Fixed invalid AppData file"
-msgstr ""
+msgstr "修正無效的 AppData 檔案"
 
 #: data/com.github.johnfactotum.Foliate.appdata.xml.in:52
 msgid "Initial release"
-msgstr ""
+msgstr "首次發布"
 
 #: src/main.js:37
 msgid "Light"
@@ -151,186 +151,208 @@ msgstr "下一頁"
 msgid "Go back"
 msgstr "返回"
 
-#: src/main.js:684
+#: src/main.js:694
 msgid "No bookmarks"
 msgstr "沒有書籤"
 
-#: src/main.js:685
+#: src/main.js:695
 msgid "Add some bookmarks to see them here."
 msgstr "新增書籤之後，就可以在這裡檢視它們"
 
-#: src/main.js:721
+#: src/main.js:731
 msgid "Bookmark Current Location"
 msgstr "將目前位置加入書籤"
 
-#: src/main.js:726
+#: src/main.js:736
 msgid "Remove Current Location"
 msgstr "移除目前位置"
 
-#: src/main.js:743
+#: src/main.js:753
 msgid "No annotations"
 msgstr "沒有註解"
 
-#: src/main.js:744
+#: src/main.js:754
 msgid "Highlight some text to add annotations."
 msgstr "選取一些文字以新增註解"
 
-#: src/main.js:782 src/main.js:858
+#: src/main.js:792 src/main.js:868
 msgid "Copy"
 msgstr "複製"
 
-#: src/main.js:787
+#: src/main.js:797
 msgid "Highlight"
 msgstr "註解"
 
-#: src/main.js:796
+#: src/main.js:806
 msgid "Loading…"
 msgstr "載入中…"
 
-#: src/main.js:805
+#: src/main.js:815
 msgid "From Wiktionary, the free dictionary"
 msgstr "來自維基辭典，自由的多語言辭典"
 
-#: src/main.js:843
+#: src/main.js:853
 msgid "View Full Definition"
 msgstr "檢視完整定義"
 
-#: src/main.js:863
+#: src/main.js:873
 msgid "Remove"
 msgstr "移除"
 
-#: src/main.js:868
+#: src/main.js:878
 msgid "Note"
 msgstr "筆記"
 
-#: src/main.js:943
+#: src/main.js:953
 msgid "Open some books to start reading"
 msgstr "開啟電子書以開始閱讀"
 
-#: src/main.js:948
+#: src/main.js:958
 msgid "Open a file, or continue reading the last opened book."
 msgstr "開啟檔案，或繼續閱讀上次開啟的電子書"
 
-#: src/main.js:952
+#: src/main.js:962
 msgid "Open File…"
 msgstr "開啟檔案…"
 
-#: src/main.js:956
+#: src/main.js:966
 msgid "Continue Reading"
 msgstr "繼續閱讀"
 
-#: src/main.js:1075
+#: src/main.js:1087
 msgid "Oh no! The file cannot be opened"
 msgstr "噢不！無法開啟檔案"
 
-#: src/main.js:1322
+#: src/main.js:1355
 msgid "Table of contents"
 msgstr "目錄"
 
-#: src/main.js:1348
+#: src/main.js:1381
 msgid "Set font, theme, and layout"
 msgstr "設定字體、主題與版面"
 
-#: src/main.js:1363
+#: src/main.js:1396
 msgid "Bookmarks"
 msgstr "書籤"
 
-#: src/main.js:1377
+#: src/main.js:1410
 msgid "Annotations"
 msgstr "註解"
 
-#: src/main.js:1407
+#: src/main.js:1446
 msgid "Open…"
 msgstr "開啟…"
 
-#: src/main.js:1411
+#: src/main.js:1447
+msgid "Fullscreen"
+msgstr "全螢幕"
+
+#: src/main.js:1451
 msgid "Keyboard Shortcuts"
 msgstr "鍵盤捷徑鍵"
 
-#: src/main.js:1412
+#: src/main.js:1452
 msgid "About Foliate"
 msgstr "關於 Foliate"
 
-#: src/main.js:1422 src/main.js:1442
+#: src/main.js:1479 src/main.js:1499
 msgid "About This Book"
 msgstr "關於這本書"
 
-#: src/main.js:1505
+#: src/main.js:1562
 msgid "Publisher"
 msgstr "出版社"
 
-#: src/main.js:1506
+#: src/main.js:1563
 msgid "Publication Date"
 msgstr "出版日期"
 
-#: src/main.js:1507
+#: src/main.js:1564
 msgid "Modified Date"
 msgstr "修改日期"
 
-#: src/main.js:1508
+#: src/main.js:1565
 msgid "Language"
 msgstr "語言"
 
-#: src/main.js:1509
+#: src/main.js:1566
 msgid "Copyright"
 msgstr "版權"
 
-#: src/main.js:1510
+#: src/main.js:1567
 msgid "Identifier"
 msgstr "識別碼"
 
-#: src/main.js:1583
+#: src/main.js:1640
 msgid "All files"
 msgstr "所有檔案"
 
-#: src/main.js:1587
+#: src/main.js:1644
 msgid "EPUB files"
 msgstr "EPUB 檔案"
 
-#: src/main.js:1609
+#: src/main.js:1673
 msgid "General"
 msgstr "一般"
 
-#: src/main.js:1611
+#: src/main.js:1675
 msgid "Show table of contents"
 msgstr "顯示目錄"
 
-#: src/main.js:1612
+#: src/main.js:1676
 msgid "Show bookmarks"
 msgstr "顯示書籤"
 
-#: src/main.js:1613
+#: src/main.js:1678
 msgid "Show menu"
 msgstr "顯示選單"
 
-#: src/main.js:1617
+#: src/main.js:1682
 msgid "Navigation"
 msgstr "瀏覽"
 
-#: src/main.js:1619
+#. I can't find where to access the enums in GJS,
+#. so just use ints for now
+#: src/main.js:1684 src/main.js:1702
 msgid "Go to the next page"
 msgstr "前往下一頁"
 
-#: src/main.js:1620
+#: src/main.js:1685 src/main.js:1703
 msgid "Go to the previous page"
 msgstr "前往上一頁"
 
-#: src/main.js:1624
-msgid "Search"
-msgstr "搜尋"
+#: src/main.js:1686
+msgid "Go back to previous location"
+msgstr "返回先前位置"
 
-#: src/main.js:1630
+#: src/main.js:1690
 msgid "View"
 msgstr "檢視"
 
-#: src/main.js:1632
+#: src/main.js:1692
 msgid "Increase font size"
 msgstr "放大字體"
 
-#: src/main.js:1633
+#: src/main.js:1693
 msgid "Decrease font size"
 msgstr "縮小字體"
 
-#: src/main.js:1662
+#: src/main.js:1694
+msgid "Toggle fullscreen"
+msgstr "切換全螢幕"
+
+#: src/main.js:1698
+msgid "Touchpad Gestures"
+msgstr "觸控板手勢"
+
+#: src/main.js:1704
+msgid "Zoom in"
+msgstr "放大"
+
+#: src/main.js:1705
+msgid "Zoom out"
+msgstr "縮小"
+
+#: src/main.js:1734
 msgid "A simple eBook viewer"
 msgstr "一個簡單的電子書閱讀器"

--- a/src/main.js
+++ b/src/main.js
@@ -1052,12 +1052,12 @@ class BookViewerWindow {
         })
         
         this.container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL })
-        const overlay = new Gtk.Overlay()
-        overlay.add(this.webView)
-        overlay.add_overlay(this.spinner)
+        this.overlay = new Gtk.Overlay()
+        this.overlay.add(this.webView)
+        this.overlay.add_overlay(this.spinner)
         this.webView.opacity = 0
 
-        this.container.pack_start(overlay, true, true, 0)
+        this.container.pack_start(this.overlay, true, true, 0)
         this.window.add(this.container)
         this.window.show_all()
     }
@@ -1074,7 +1074,7 @@ class BookViewerWindow {
             })
     }
     bookError() {
-        this.spinner.destroy()
+        this.overlay.destroy()
         const box = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL,
             valign: Gtk.Align.CENTER


### PR DESCRIPTION
While building package, gjs wasn't listed as runtime dependency so users have to install it alongside for the time being.

I will fix this in next revision of the package, and will open a PR to remove gjs from instructions.