### PR TITLE
Add Void Linux instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Website: https://johnfactotum.github.io/foliate/
 
 For Arch Linux users, two packages are available on the AUR: [`foliate`](https://aur.archlinux.org/packages/foliate/) (stable version), [`foliate-git`](https://aur.archlinux.org/packages/foliate-git/) (Git version)
 
-For Void Linux users, foliate is available in Void's official repository. Install using xbps: `xbps-install -S foliate gjs`
+For Void Linux users, foliate is available in Void's official repository. Install using xbps: `xbps-install -S foliate`
+
+Note:xbps will not install gjs dependency. Install it with: `xbps-install -S gjs`
 
 ### Install manually from source
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Website: https://johnfactotum.github.io/foliate/
 
 For Arch Linux users, two packages are available on the AUR: [`foliate`](https://aur.archlinux.org/packages/foliate/) (stable version), [`foliate-git`](https://aur.archlinux.org/packages/foliate-git/) (Git version)
 
+For Void Linux users, foliate is available in Void's official repository. Install using xbps: `xbps-install -S foliate gjs`
+
 ### Install manually from source
 
 First, you'll need the following dependencies:


### PR DESCRIPTION
While building package, gjs wasn't listed as runtime dependency so users have to install it alongside for the time being.

I will fix this in next revision of the package, and will open a PR to remove gjs from instructions.