### PR TITLE
Remove note from Void instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ For Arch Linux users, two packages are available on the AUR: [`foliate`](https:/
 
 For Void Linux users, foliate is available in Void's official repository. Install using xbps: `xbps-install -S foliate`
 
-Note:xbps will not install gjs dependency. Install it with: `xbps-install -S gjs`
-
 ### Install manually from source
 
 First, you'll need the following dependencies:


### PR DESCRIPTION
xbps will now handle all dependencies itself.