### PR TITLE
build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ First, you'll need the following dependencies:
 - `webkit2gtk`
 - `libsoup`
 - `meson`
+- `gettext`
 
 Then run the follwing commands:
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
-project('com.github.johnfactotum.Foliate',  
+project('com.github.johnfactotum.Foliate',
         version: '1.2.1',
-  meson_version: '>= 0.40.0',
+  meson_version: '>= 0.50.0',
 )
 
 i18n = import('i18n')


### PR DESCRIPTION
Hi! Thanks for foliate. Fixed some build related stuff for you:

minimum meson ver needs to be bumped to 0.50.0

```
WARNING: Project targetting '>= 0.40.0' but tried to use feature introduced in '0.50.0': install arg in configure_file
Configuring com.github.johnfactotum.Foliate using configuration
Program build-aux/meson/postinstall.py found: YES (/home/josh/bin/src/foliate/build-aux/meson/postinstall.py)
Build targets in project: 7
WARNING: Project specifies a minimum meson_version '>= 0.40.0' but uses features which were added in newer versions:
 * 0.50.0: {'install arg in configure_file'}
```

`gettext` is required for the build

```
po/meson.build:1:5: ERROR: Can not do gettext because xgettext is not installed.
```
