### PR TITLE
Add option to disable fast annotation (impl #98)

### DIFF
--- a/data/com.github.johnfactotum.Foliate.gschema.xml
+++ b/data/com.github.johnfactotum.Foliate.gschema.xml
@@ -66,6 +66,11 @@
             <summary>Lookup enabled</summary>
             <description>If true, dictionary lookup is enabled</description>
         </key>
+        <key name="fastannotation-enabled" type="b">
+            <default>true</default>
+            <summary>Fast Annotation enabled</summary>
+            <description>If true, selection as annotation is enabled</description>
+        </key>
         <key name="autohide-cursor" enum="com.github.johnfactotum.Foliate.AutohideCursor">
             <default>'fullscreen'</default>
             <summary>Auto-hide cursor</summary>
@@ -111,5 +116,5 @@
             <summary>Sidebar page</summary>
             <description>Sidebar page</description>
         </key>
-	</schema>
+    </schema>
 </schemalist>

--- a/src/assets/viewer.html
+++ b/src/assets/viewer.html
@@ -71,6 +71,7 @@ let annotation
 let lookupEnabled = true
 let lookupResults
 let lookupLang = 'English'
+let fastAnnotationEnabled = true
 let footnote, followLink = () => {}
 let autohideCursor, screenX, screenY, cursorHidden
 let windowSize
@@ -363,6 +364,7 @@ const setupRendition = () => {
             }, false)
         })
 
+        let latestSelectionRange = null
         contents.document.onmouseup = () => {
             const selection = contents.window.getSelection()
             const range = selection.getRangeAt(0)
@@ -391,6 +393,12 @@ const setupRendition = () => {
                     }
                 })
             } else {
+                if (!fastAnnotationEnabled &&
+                    (latestSelectionRange === null || latestSelectionRange != cfiRange)) {
+                    latestSelectionRange = cfiRange
+                    return
+                }
+
                 annotation = { text, cfiRange }
                 dispatch({
                     type: 'annotation-add',
@@ -496,7 +504,7 @@ const queryDictionary = (html, word) => new Promise((resolve, reject) => {
         if (!language) return
         const $language = $(el).nextUntil('h2')
         const $$sections = $language.filter('h3')
-        
+
         const sectionsResult = {}
         $$sections.each((i, el) => {
             const section = $(el).children('.mw-headline').text()
@@ -504,7 +512,7 @@ const queryDictionary = (html, word) => new Promise((resolve, reject) => {
                 $(el).nextUntil('h2'),
                 $(el).nextUntil('h3')], x => x.length)
             const $$subsections = $section.filter('h4')
-            
+
             if (!/Etymology \d+/.test(section)) {
                 const content = getContent(section, $section, $)
                 if (content.length) sectionsResult[section] = content
@@ -516,7 +524,7 @@ const queryDictionary = (html, word) => new Promise((resolve, reject) => {
                         $(el).nextUntil('h2'),
                         $(el).nextUntil('h3'),
                         $(el).nextUntil('h4')], x => x.length)
-                    
+
                     const content = getContent(subsection, $subsection, $)
                     if (content.length) subsectionsResult[subsection] = content
                 })

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 'use strict'
- 
+
 pkg.initGettext()
 const ngettext = imports.gettext.ngettext
 pkg.initFormat()
@@ -77,7 +77,7 @@ class Storage {
         this._destination = GLib.build_filenamev([dataDir, pkg.name,
             `${encodeURIComponent(key)}.json`])
         this._file = Gio.File.new_for_path(this._destination)
-        
+
         this._data = this._read()
     }
     _read() {
@@ -128,7 +128,7 @@ class Navbar {
     constructor(onSlide, onPrev, onNext, onBack) {
         this._percentage = NaN
         this._history = []
-        
+
         this._slider = new Gtk.Scale({
             orientation: Gtk.Orientation.HORIZONTAL,
             adjustment: new Gtk.Adjustment({ value: 0, lower: 0, upper: 1 }),
@@ -153,7 +153,7 @@ class Navbar {
         this._pendingLabel = new Gtk.Image({ icon_name: 'content-loading-symbolic' })
         box.pack_start(this._pendingLabel, true, true, 0)
         box.pack_start(this._slider, true, true, 0)
-        
+
         this._backButton = new Gtk.Button({
             image: new Gtk.Image({ icon_name: 'edit-undo-symbolic' }),
             tooltip_text: _('Go back'),
@@ -166,13 +166,13 @@ class Navbar {
             if (!this._history.length) this._backButton.sensitive = false
         }
         this._backButton.connect('clicked', this.goBack)
-        
+
         this.widget = new Gtk.ActionBar()
         this.widget.pack_start(this._prevButton)
         this.widget.pack_start(this._backButton)
         this.widget.pack_end(this._nextButton)
         this.widget.pack_end(box)
-        
+
         this._slider.connect('button-release-event', () => {
             const value = this._slider.get_value()
             if (value !== this._percentage) onSlide(this._slider.get_value())
@@ -309,7 +309,7 @@ class JumpList {
         }
         col.pack_start(text, true)
         col.add_attribute(text, 'markup', 0)
-        
+
         const selection = view.get_selection()
         view.set_activate_on_single_click(true)
         view.connect('row-activated', () => {
@@ -317,7 +317,7 @@ class JumpList {
             const href = store.get_value(iter, 1)
             onChange(href)
         })
-        
+
         const scroll = new Gtk.ScrolledWindow({
             min_content_width: width,
             min_content_height: height
@@ -325,7 +325,7 @@ class JumpList {
         if (frame) scroll.get_style_context().add_class('frame')
         if (!isToc) scroll.hscrollbar_policy = Gtk.PolicyType.NEVER
         scroll.add(view)
-        
+
         this.store = store
         this.view = view
         this.widget = scroll
@@ -424,14 +424,14 @@ class SearchPopover {
         inChapterButton.connect('toggled', search)
         rangeBox.pack_start(inBookButton, false, true, 0)
         rangeBox.pack_start(inChapterButton, false, true, 0)
-        
+
         this._jumpList = new JumpList(320, 350, false, href => {
             onChange(href)
             button.active = false
         }, true)
         this._statusLabel = new Gtk.Label({ halign: Gtk.Align.START })
         this._statusLabel.get_style_context().add_class('dim-label')
-        
+
         const box = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL, spacing: 10
         })
@@ -474,7 +474,7 @@ class SearchPopover {
 class FontBox {
     constructor(onChange) {
         this._onChange = onChange
-        
+
         const fontBox = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL })
         fontBox.get_style_context().add_class('linked')
         this._fontButton = new Gtk.FontButton({
@@ -499,7 +499,7 @@ class FontBox {
         fontBox.pack_start(this._fontButton, true, true, 0)
         fontBox.pack_start(this._decButton, false, true, 0)
         fontBox.pack_start(this._incButton, false, true, 0)
-        
+
         this.widget = fontBox
     }
     applyFont()  {
@@ -590,12 +590,12 @@ class SwitchBox {
 class ViewPopover {
     constructor(themes, onChange, onLayoutChange) {
         this.widget = new Gtk.Popover({ border_width: 10 })
-        
+
         const grid = new Gtk.Grid()
         grid.column_spacing = 10
         grid.row_spacing = 10
         this._grid = grid
-        
+
         const onViewChange = () => {
             const font = this._fontBox.getFont()
             const spacing = this._spacingButton.get_value()
@@ -614,7 +614,7 @@ class ViewPopover {
         this._fontBox = new FontBox(onViewChange)
         this._themeBox = new RadioBox(Object.keys(themes), onViewChange)
         this._layoutBox = new RadioBox(Object.keys(defaultLayouts), onLayoutChange)
-        
+
         this._defaultSwitch = new SwitchBox(_('Use Publisher Font'),
             'use-default-font', onViewChange)
         this._justifySwitch = new SwitchBox(_('Full Justification'),
@@ -643,7 +643,7 @@ class ViewPopover {
         this._brightnessSlider.connect('format-value', (_, x) => `${Math.round(x * 100)}%`)
         this._brightnessSlider.add_mark(1, Gtk.PositionType.TOP, null)
         this._brightnessSlider.connect('value-changed', onViewChange)
-        
+
         const menuLabels = {
             font: new Gtk.Label({ label: _('Font') }),
             spacing: new Gtk.Label({ label: _('Spacing') }),
@@ -733,7 +733,7 @@ class NotesList {
         this._listBox.set_header_func(row => {
             if (row.get_index()) row.set_header(new Gtk.Separator())
         })
-        
+
         this._rowMap = new Map() // GtkRow -> value, for row activation
         this._removeMap = new Map() // value -> removeFunc, for removing by value
         this._labelMap = new Map() // value -> GtkLabel
@@ -742,18 +742,18 @@ class NotesList {
 
         this._listBox.connect('row-activated', (_, row) =>
             onActivate(this._rowMap.get(row)))
-        
+
         const scroll = new Gtk.ScrolledWindow({
             min_content_width: width,
             min_content_height: height
         })
         if (frame) scroll.get_style_context().add_class('frame')
         scroll.add(this._listBox)
-        
+
         this.widget = new Gtk.Stack()
         this.widget.add_named(scroll, 'list')
         this.widget.add_named(this._buildEmptyState(width, height, emptyState),'empty')
-        
+
         this._emptyState.show()
         scroll.hide()
         this._onChange = (...args) => {
@@ -790,7 +790,7 @@ class NotesList {
         })
         messageLabel.set_line_wrap(true)
         messageLabel.get_style_context().add_class('dim-label')
-        
+
         const box = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL,
             valign: Gtk.Align.CENTER,
@@ -799,7 +799,7 @@ class NotesList {
         box.pack_start(image, false, true, 0)
         box.pack_start(titleLabel, false, true, 0)
         box.pack_start(messageLabel, false, true, 0)
-        
+
         this._emptyState = new Gtk.ScrolledWindow({ width_request: width, height_request: height })
         if (this._frame) this._emptyState.get_style_context().add_class('frame')
         this._emptyState.add(box)
@@ -836,12 +836,12 @@ class NotesList {
             relief: Gtk.ReliefStyle.NONE,
             valign: Gtk.Align.CENTER
         })
-        
+
         this._rowMap.set(row, value)
         if (data) this._dataMap.set(value, data)
         this._labelMap.set(value, label)
         this._label2Map.set(value, label2)
-        
+
         const removeFunc = () => {
             this._listBox.remove(row)
             this._rowMap.delete(row)
@@ -854,7 +854,7 @@ class NotesList {
         }
         this._removeMap.set(value, removeFunc)
         button.connect('clicked', removeFunc)
-        
+
         const box = new Gtk.Box({ spacing: 3 })
         box.pack_start(label, true, true, 0)
         box.pack_end(button, false, true, 0)
@@ -863,7 +863,7 @@ class NotesList {
         box2.pack_start(box, true, true, 0)
         box2.pack_end(label2, true, true, 0)
         row.add(box2)
-        
+
         row.show_all()
         if (!text2) label2.hide()
         this._listBox.add(row)
@@ -913,7 +913,7 @@ class Bookmarks {
         this._addFunc = () => onAdd(add)
         this._addButton.connect('clicked', () => this.doButtonAction())
         this.setCanAdd()
-        
+
         const bookmarksBox = new Gtk.Box({
             orientation: Gtk.Orientation.VERTICAL, spacing: frame ? 10 : 0
         })
@@ -992,7 +992,7 @@ class Annotations {
 class LookupPopover {
     constructor(relative_to, position, fromTop, onAnnotate, onCopy) {
         this.widget = new Gtk.Popover({ border_width: 10, relative_to })
-        
+
         const actionBox = new Gtk.Box()
         actionBox.get_style_context().add_class('linked')
         const copyButton = new Gtk.Button({ label: _('Copy') })
@@ -1007,7 +1007,7 @@ class LookupPopover {
         })
         actionBox.pack_start(noteButton, true, true, 0)
         actionBox.pack_start(copyButton, true, true, 0)
-        
+
         this.label = new Gtk.Label({
             label: _('Loading…'),
             use_markup: true,
@@ -1016,13 +1016,13 @@ class LookupPopover {
             xalign: 0
         })
         this.label.set_line_wrap(true)
-        
+
         const credit = new Gtk.Label({
             label: _('From Wiktionary, the free dictionary'),
             justify: Gtk.Justification.CENTER
         })
         credit.get_style_context().add_class('dim-label')
-        
+
         const scroll = new Gtk.ScrolledWindow({
             min_content_width: 300,
             min_content_height: 200
@@ -1036,19 +1036,19 @@ class LookupPopover {
         this.lbox.pack_start(this.label, true, true, 0)
         scroll.get_style_context().add_class('frame')
         scroll.add(this.lbox)
-        
+
         const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 10 })
         box.pack_start(actionBox, false, true, 0)
         box.pack_end(scroll, true, true, 0)
-        
+
         this.widget.add(box)
-        
+
         if (fromTop) this.widget.set_position(Gtk.PositionType.TOP)
         else this.widget.set_position(Gtk.PositionType.BOTTOM)
         const rectangle = new Gdk.Rectangle(position)
         this.widget.set_pointing_to(rectangle)
         box.show_all()
-        
+
         this.widget.popup()
     }
     loadResults(label, word) {
@@ -1068,7 +1068,7 @@ class LookupPopover {
 class AnnotationPopover {
     constructor(relative_to, position, fromTop, onRemove, onCopy, color, onColorChange, note, onNoteChange) {
         this.widget = new Gtk.Popover({ border_width: 10, relative_to })
-        
+
         const actionBox = new Gtk.Box()
         actionBox.get_style_context().add_class('linked')
         const copyButton = new Gtk.Button({ label: _('Copy') })
@@ -1086,7 +1086,7 @@ class AnnotationPopover {
             scroll.visible = noteButton.active
             if (noteButton.active) textView.grab_focus()
         })
-        
+
         const model = new Gtk.ListStore()
         model.set_column_types([GObject.TYPE_STRING, GObject.TYPE_STRING])
 
@@ -1105,12 +1105,12 @@ class AnnotationPopover {
             const value = model.get_value(iter, 0)
             onColorChange(value)
         })
-        
+
         actionBox.pack_start(comboBox, true, true, 0)
         actionBox.pack_start(noteButton, true, true, 0)
         actionBox.pack_start(removeButton, true, true, 0)
         actionBox.pack_start(copyButton, true, true, 0)
-        
+
         const textView = new Gtk.TextView({ wrap_mode: Gtk.WrapMode.WORD })
         const buffer = textView.get_buffer()
         const scroll = new Gtk.ScrolledWindow({
@@ -1118,19 +1118,19 @@ class AnnotationPopover {
         })
         scroll.get_style_context().add_class('frame')
         scroll.add(textView)
-        
+
         const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 10 })
         box.pack_start(actionBox, false, true, 0)
         box.pack_end(scroll, true, true, 0)
-        
+
         this.widget.add(box)
-        
+
         if (fromTop) this.widget.set_position(Gtk.PositionType.TOP)
         else this.widget.set_position(Gtk.PositionType.BOTTOM)
         const rectangle = new Gdk.Rectangle(position)
         this.widget.set_pointing_to(rectangle)
         box.show_all()
-        
+
         if (note) {
             buffer.text = note
             noteButton.active = true
@@ -1138,7 +1138,7 @@ class AnnotationPopover {
         buffer.connect('changed', () => {
             onNoteChange(buffer.text)
         })
-        
+
         this.widget.popup()
     }
 }
@@ -1227,7 +1227,7 @@ class BookViewerWindow {
             default_width: width,
             default_height: height
         })
-        
+
         let windowWidth, windowHeight, windowMaximized
         this.window.connect('size-allocate', () => {
             [windowWidth, windowHeight] = this.window.get_size()
@@ -1238,16 +1238,16 @@ class BookViewerWindow {
             settings.set_int('window-height', windowHeight)
             settings.set_boolean('window-maximized', windowMaximized)
         })
-        
+
         this.activateTheme()
-        
+
         this.headerBar = new Gtk.HeaderBar()
         this.headerBar.show_close_button = true
         this.headerBar.has_subtitle = false
         this.window.set_titlebar(this.headerBar)
         this.window.title = _('Foliate')
         this.window.show_all()
-        
+
         this.buildMenu()
         if (fileName) this.open(fileName)
         else {
@@ -1271,14 +1271,14 @@ class BookViewerWindow {
             height_request: 48
         })
         this.spinner.start()
-        
+
         this.webViewSettings = new Webkit.Settings({
             enable_write_console_messages_to_stdout: true,
             allow_file_access_from_file_urls: true
         })
         this.webView = new Webkit.WebView({ settings: this.webViewSettings })
         this.webView.connect('context-menu', () => true)
-        
+
         this.webView.load_uri(GLib.filename_to_uri(pkg.pkgdatadir + '/assets/viewer.html', null))
         this.webView.connect('notify::title', self => {
             const action = JSON.parse(self.title)
@@ -1286,7 +1286,7 @@ class BookViewerWindow {
                 this.scriptRun(`openBook("${encodeURI(fileName)}")`)
             else this.handleAction(action)
         })
-        
+
         this.container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL })
         this.overlay = new Gtk.Overlay()
         this.overlay.add(this.webView)
@@ -1402,6 +1402,7 @@ class BookViewerWindow {
         })
 
         this.scriptRun(`lookupEnabled = ${settings.get_boolean('lookup-enabled')}`)
+        this.scriptRun(`fastAnnotationEnabled = ${settings.get_boolean('fastannotation-enabled')}`)
 
         this.buildView(this.themes, ({
             font, spacing, margin, brightness, theme, useDefault, justify, hyphenate
@@ -1414,10 +1415,10 @@ class BookViewerWindow {
 
             const { color, background, link, darkMode, invert } =
                 this.themes[theme]
-            
+
             Gtk.Settings.get_default()
                 .gtk_application_prefer_dark_theme = darkMode
-            
+
             const fontFamily = font.desc.get_family()
             const fontSize = `${font.desc.get_size() / Pango.SCALE}pt`
             const fontWeight = font.desc.get_weight()
@@ -1511,7 +1512,7 @@ class BookViewerWindow {
             settings.get_double('brightness'),
             settings.get_string('theme'),
             settings.get_string('layout'))
-        
+
         settings.connect('changed::theme', () => {
             const theme = settings.get_string('theme')
             if (theme !== this.viewPopover.theme) this.viewPopover.theme = theme
@@ -1610,7 +1611,7 @@ class BookViewerWindow {
                     const color = settings.get_string('highlight')
                     const data = { color, text }
                     this.scriptRun(`addAnnotation('${cfiRange}', '${color}')`)
-                    
+
                     const label = coloredText(color, text)
                     this.annotations.add(label, null, cfiRange, data)
                     this.scriptRun(`dispatch({
@@ -1624,7 +1625,7 @@ class BookViewerWindow {
                 const [, winHeight] = this.window.get_size()
                 const fromTop = position.top >= winHeight / 2
                 const y = fromTop ? position.top : position.bottom
-                
+
                 const data = this.annotations.getData(cfiRange)
                 new AnnotationPopover(
                     this.webView, { x: position.left, y }, fromTop,
@@ -1962,7 +1963,7 @@ class BookViewerWindow {
         this.headerBar.pack_start(tocButton)
         this.headerBar.pack_start(annotationsButton)
         this.headerBar.pack_start(bookmarksButton)
-        
+
         this.addShortcut(['F9'], 'toc-popover', () =>
             tocButton.active = !tocButton.active)
         this.addShortcut(['<Control>b'], 'bookmark-popover', () =>
@@ -1976,7 +1977,7 @@ class BookViewerWindow {
         if (!settings.get_boolean('show-navbar')) this.navbar.widget.hide()
         this.navbar.setPending()
         this.container.pack_end(this.navbar.widget, false, true, 0)
-        
+
         this.addShortcut(['p', 'h'], 'go-prev', onPrev)
         this.addShortcut(['n', 'l'], 'go-next', onNext)
 
@@ -2010,13 +2011,14 @@ class BookViewerWindow {
         })
         const popover = new Gtk.Popover()
         button.popover = popover
-        
+
         this.menu = new Gio.Menu()
-        
+
         const section1 = new Gio.Menu()
         section1.append(_('Fullscreen'), 'win.fullscreen')
         section1.append(_('Reading Progress Bar'), 'win.navbar')
         section1.append(_('Enable Dictionary'), 'win.lookup')
+        section1.append(_('Enable Fast Annotation'), 'win.fastannotation')
         this.menu.append_section(null, section1)
 
         const section2 = new Gio.Menu()
@@ -2099,6 +2101,18 @@ class BookViewerWindow {
         })
         this.window.add_action(lookupAction)
 
+        const fastAnnotationAction = new Gio.SimpleAction({
+            name: 'fastannotation',
+            state: new GLib.Variant('b', settings.get_boolean('fastannotation-enabled'))
+        })
+        fastAnnotationAction.connect('activate', () => {
+            const state = !fastAnnotationAction.get_state().get_boolean()
+            this.scriptRun(`fastAnnotationEnabled = ${state}`)
+            fastAnnotationAction.set_state(new GLib.Variant('b', state))
+            settings.set_boolean('fastannotation-enabled', state)
+        })
+        this.window.add_action(fastAnnotationAction)
+
         const closeAction = new Gio.SimpleAction({ name: 'close' })
         closeAction.connect('activate', () => this.window.close())
         this.window.add_action(closeAction)
@@ -2108,7 +2122,7 @@ class BookViewerWindow {
         const section = new Gio.Menu()
         section.append(_('About This Book'), 'win.properties')
         this.menu.prepend_section(null, section)
-        
+
         const action = new Gio.SimpleAction({ name: 'properties' })
         action.connect('activate', () => {
             let image
@@ -2116,11 +2130,11 @@ class BookViewerWindow {
                 const data = GLib.base64_decode(coverBase64)
                 const imageStream = Gio.MemoryInputStream.new_from_bytes(data)
                 const pixbuf = GdkPixbuf.Pixbuf.new_from_stream(imageStream, null)
-                
+
                 const width = 200
                 const ratio = width / pixbuf.get_width()
                 const height = parseInt(pixbuf.get_height() * ratio, 10)
-                
+
                 image = Gtk.Image.new_from_pixbuf(
                     pixbuf.scale_simple(width, height, GdkPixbuf.InterpType.BILINEAR))
             }
@@ -2131,7 +2145,7 @@ class BookViewerWindow {
                 has_subtitle: false
             })
             window.set_titlebar(headerBar)
-            
+
             const dataBox = new Gtk.Box({
                 orientation: Gtk.Orientation.VERTICAL, spacing: 10
             })
@@ -2147,7 +2161,7 @@ class BookViewerWindow {
             })
             title.set_line_wrap(true)
             dataBox.pack_start(title, false, true, 0)
-            
+
             if (metadata.creator) {
                 const creator = new Gtk.Label({
                     label: metadata.creator,
@@ -2184,7 +2198,7 @@ class BookViewerWindow {
                 frame.add(webView)
                 dataBox.pack_start(frame, true, true, 0)
             }
-            
+
             // workaround for xgettext bug
             // `/`
 
@@ -2192,13 +2206,13 @@ class BookViewerWindow {
                 column_spacing: 10, row_spacing: 10,
                 valign: Gtk.Align.CENTER
             })
-            
+
             dataBox.pack_end(grid, false, true, 0)
-            
+
             let row = 0
             for (const key in metadata) {
                 if (!metadata[key]) continue
-                
+
                 const labelText = {
                     publisher: _('Publisher'),
                     pubdate: _('Publication Date'),
@@ -2216,7 +2230,7 @@ class BookViewerWindow {
                     })
                     label.get_style_context().add_class('dim-label')
                     grid.attach(label, 0, row, 1, 1)
-                    
+
                     const value = new Gtk.Label({
                         label: metadata[key],
                         selectable: true,
@@ -2240,7 +2254,7 @@ class BookViewerWindow {
             } else if (image) image.valign = Gtk.Align.START
             if (image) coverBox.pack_start(image, false, true, 0)
             coverBox.pack_end(dataBox, false, true, 0)
-            
+
             const container = window.get_content_area()
             container.border_width = 18
             container.pack_start(coverBox, true, true, 0)


### PR DESCRIPTION
This PR impl #98 

Idea is, when selection appear in `contents.document.onmouseup`, save the `cfiRange` as `latestSelectionRange` and not add into annotation at this round. When user trigger `onmouseup` event again, check if current selection range is same as `latestSelectionRange`, if so, then add it into annotations.

Second commit add the option in menu to enable/disable this function
