### PR TITLE
Popup extraction extra checks

### DIFF
--- a/src/assets/viewer.js
+++ b/src/assets/viewer.js
@@ -327,20 +327,33 @@ const setupRendition = () => {
                 })
                 else {
                     const [page, id] = href.split('#')
-                    let el = contents.document.getElementById(id)
-                    if (!el) return dispatch({
-                        type: 'link-internal',
-                        payload: rendition.currentLocation().start.cfi
-                    })
+                    var el = contents.document.getElementById(id)
 
-                    if (el.nodeName === 'A' && el.getAttribute('href')) {
-                        while (true) {
-                            const parent = el.parentElement
-                            if (!parent) break
-                            const text = el.innerText
-                            el = parent
-                            if (parent.innerText !== text) break
+                    if (!el) {
+                        try {
+                            var sectionLink = book.spine.get(page)
+                            var a = sectionLink.document.body.getElementsByTagName("A")
+                            var b = Array.prototype.slice.call(a)
+                            b.forEach(function(n) {
+                                if (n.id === id) footnote = n.parentNode.innerText
+                            })
+                        } catch (err) {
+                            return dispatch({
+                                type: 'link-internal',
+                                payload: rendition.currentLocation().start.cfi
+                            })
+                        } 
+                    } else {
+                        if (el.nodeName === 'A' && el.getAttribute('href')) {
+                            while (true) {
+                                const parent = el.parentElement
+                                if (!parent) break
+                                const text = el.innerText
+                                el = parent
+                                if (parent.innerText !== text) break
+                            }
                         }
+                        footnote = el.innerText.trim()
                     }
 
                     const rect = e.target.getBoundingClientRect()
@@ -350,7 +363,6 @@ const setupRendition = () => {
                     const top = rect.top + viewElementRect.top
                     const bottom = rect.bottom + viewElementRect.top
 
-                    footnote = el.innerText.trim()
                     followLink = () => {
                         dispatch({
                             type: 'link-internal',
@@ -358,6 +370,7 @@ const setupRendition = () => {
                         })
                         link.onclick()
                     }
+
                     if (footnote) dispatch({
                         type: 'footnote',
                         payload: { left, right, top, bottom, canGoTo: !(type === 'noteref') }


### PR DESCRIPTION
New code seeks footnotes (https://github.com/johnfactotum/foliate/issues/127) in other chapters and returns them as a text for a popup, if they are found. If not, treats them like 'link-internal' and goes to link.

Some epubs (defective or not epub3) can go to an earlier chapter/link, than expected, but that happens even without this popup extraction code.