### PR TITLE
Fix glyph clipping in WebKit. Fixes #177

### DIFF
--- a/src/assets/epub.js
+++ b/src/assets/epub.js
@@ -5280,6 +5280,10 @@ var Contents = function () {
 
 			this.css(COLUMN_GAP, gap + "px");
 			this.css(COLUMN_WIDTH, columnWidth + "px");
+
+			// Fix glyph clipping in WebKit
+			// https://github.com/futurepress/epub.js/issues/983
+			this.css("-webkit-line-box-contain", "block glyphs replaced");
 		}
 
 		/**


### PR DESCRIPTION
Before:
![Screenshot from 2019-09-28 22-23-21](https://user-images.githubusercontent.com/1264014/65822068-a4aa8880-e23e-11e9-80ad-ce8870bd4696.png)

After:
![Screenshot from 2019-09-28 22-22-38](https://user-images.githubusercontent.com/1264014/65822069-a7a57900-e23e-11e9-9a40-84e63f3ba8b4.png)

Does not fix glyph clipping in vertical writing modes. Shouldn't affect anything else. Got the CSS property from Apple Books' CSS.

Testing EPUB: https://djazz.se/files/testcase.epub

I have submitted an identical PR to epub.js: https://github.com/futurepress/epub.js/pull/985