### PR TITLE
Add snap to 1.x branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,16 @@ build/
 .flatpak-builder/
 .mo
 __pycache__/
+
+#snapcraft specific ignores
+/parts/
+/stage/
+/prime/
+
+*.snap
+
+.snapcraft
+__pycache__
+*.pyc
+*_source.tar.bz2
+snap/.snapcraft

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -12,6 +12,7 @@ apps:
     extensions: [gnome-3-28]
     plugs:
       - home
+      - opengl
     slots:
       - dbus-daemon
     common-id: com.github.johnfactotum.Foliate
@@ -24,6 +25,7 @@ parts:
     build-packages:
       - libgjs-dev
       - gettext
+      - libglu1-mesa
     organize:
       snap/foliate/current/usr: usr
     parse-info: [usr/share/metainfo/com.github.johnfactotum.Foliate.appdata.xml]

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: foliate
+grade: stable
+adopt-info: foliate
+license: GPL-3.0+
+
+base: core18
+confinement: strict
+
+apps:
+  foliate:
+    command: usr/bin/com.github.johnfactotum.Foliate
+    extensions: [gnome-3-28]
+    plugs:
+      - home
+    slots:
+      - dbus-daemon
+    common-id: com.github.johnfactotum.Foliate
+
+parts:
+  foliate:
+    plugin: meson
+    source: .
+    meson-parameters: [--prefix=/snap/foliate/current/usr]
+    build-packages:
+      - libgjs-dev
+      - gettext
+    organize:
+      snap/foliate/current/usr: usr
+    parse-info: [usr/share/metainfo/com.github.johnfactotum.Foliate.appdata.xml]
+
+slots:
+  dbus-daemon:
+    interface: dbus
+    bus: session
+    name: com.github.johnfactotum.Foliate


### PR DESCRIPTION
This adds the `snapcraft.yaml` manifest to the 1.x branch.

For more see https://github.com/johnfactotum/foliate/issues/240