### PR TITLE
Fix wikipedia, translation and dictionary

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ apps:
     plugs:
       - home
       - opengl
+      - network
     slots:
       - dbus-daemon
     common-id: com.github.johnfactotum.Foliate


### PR DESCRIPTION
The snap didn't have network access, but it needs it for Wikipedia, the dictionary and translation.