### PR TITLE
Snap: Support TTS and removable-media

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -15,6 +15,7 @@ apps:
       - opengl
       - network
       - audio-playback
+      - removable-media
     slots:
       - dbus-daemon
     common-id: com.github.johnfactotum.Foliate

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
       - home
       - opengl
       - network
+      - audio-playback
     slots:
       - dbus-daemon
     common-id: com.github.johnfactotum.Foliate
@@ -22,17 +23,38 @@ parts:
   foliate:
     plugin: meson
     source: .
+    override-build: |
+      set -ex
+      xmlstarlet edit -L -u "/schemalist/schema/key[@name='tts-command']/default" -v "'espeak-ng -v mb-en1'" $SNAPCRAFT_PART_BUILD/data/com.github.johnfactotum.Foliate.gschema.xml
+      snapcraftctl build
     meson-parameters: [--prefix=/snap/foliate/current/usr]
     build-packages:
       - libgjs-dev
       - gettext
       - libglu1-mesa
+      - xmlstarlet  # for override-build
     organize:
       snap/foliate/current/usr: usr
     parse-info: [usr/share/metainfo/com.github.johnfactotum.Foliate.appdata.xml]
+  tts:
+    plugin: nil
+    stage-packages:
+      - espeak-ng
+      - mbrola-en1
+      - mbrola
 
 slots:
   dbus-daemon:
     interface: dbus
     bus: session
     name: com.github.johnfactotum.Foliate
+
+layout:
+  /usr/lib/x86_64-linux-gnu/espeak-ng-data:
+    symlink: $SNAP/usr/lib/x86_64-linux-gnu/espeak-ng-data
+  # This is a bind instead of a (faster) symlink because mbrola uses LD_PRELOAD
+  # with libraries from this directory, which doesn't work with symlinks.
+  /usr/lib/x86_64-linux-gnu/mbrola:
+    bind: $SNAP/usr/lib/x86_64-linux-gnu/mbrola
+  /usr/share/mbrola:
+    symlink: $SNAP/usr/share/mbrola


### PR DESCRIPTION
Fixes https://github.com/johnfactotum/foliate/issues/327 and https://github.com/johnfactotum/foliate/issues/324

This PR adds the `removable-media` interface to allow Foliate to open files on USB sticks. This PR also adds the necessary packages for TTS in the snap. It also changes the default TTS command of the snap to `espeak-ng -v mb-en1` so that TTS is enabled by default. It think it makes sense to provide a default command for the snap since we are certain `espeak-ng` will always be available, and since users can't really choose the command themselves because it depends on what we actually packaged in the snap.

It's not ideal that users are restricted to the voices and synthesizers we ship in the snap, so I also started [a discussion on the Snapcraft forum for better support for TTS in snaps](https://forum.snapcraft.io/t/text-to-speech-support-in-snapd/17099). It would be better to either use Speech Dispatcher of the host system, or to package Speed Dispatcher itself as a snap.