### PR TITLE
fixed release date

### DIFF
--- a/data/com.github.johnfactotum.Foliate.appdata.xml.in
+++ b/data/com.github.johnfactotum.Foliate.appdata.xml.in
@@ -43,7 +43,7 @@
         </screenshot>
     </screenshots>
     <releases>
-        <release version="2.1.1" date="2019-04-09">
+        <release version="2.1.1" date="2020-04-09">
             <description>
                 <p>Fixes:</p>
                 <ul>
@@ -52,7 +52,7 @@
                 </ul>
             </description>
         </release>
-        <release version="2.1.0" date="2019-04-08">
+        <release version="2.1.0" date="2020-04-08">
             <description>
                 <p>New features:</p>
                 <ul>


### PR DESCRIPTION
I noticed on flathub that the release version of foliate was 2.0.0 rather than the latest version of 2.1.1. Though when I install from flathub and launch the app I can see it is version 2.1.1.

On flathub
![Screenshot from 2020-05-05 13-10-14](https://user-images.githubusercontent.com/56212944/81044464-06685a80-8ed2-11ea-82ad-66f1d4e267d8.png)

On using 'flatpak list' command in terminal
![Screenshot from 2020-05-05 13-10-45](https://user-images.githubusercontent.com/56212944/81044502-16803a00-8ed2-11ea-961b-352d134427f0.png)

In the installed foliate app
![Screenshot from 2020-05-05 13-11-27](https://user-images.githubusercontent.com/56212944/81044515-1e3fde80-8ed2-11ea-8757-f63ed7846481.png)

So I have corrected the release date in appdata.xml file. Please take a look.