### PR TITLE
Minor spacing change when displaying CB files

### DIFF
--- a/src/assets/webpub.js
+++ b/src/assets/webpub.js
@@ -327,10 +327,10 @@ const webpubFromComicBookArchive = async (uri, inputType, layout) => {
         `
     }
     
+    const automaticScripts = async () => { return `` }
     const fitPageScripts = async () => { return `` }
     const fitWidthScripts = async () => { return `` }
     const continuousScripts = async () => { return `` }
-    const automaticScripts = async () => { return `` }
 
     let stylesheet;
     let scripts;
@@ -378,22 +378,22 @@ const webpubFromComicBookArchive = async (uri, inputType, layout) => {
         .sort((a, b) => a.name.localeCompare(b.name))
         .map(image => {
             const html = `
-            <!doctype html>
-            <html>
-                <head>
-                    <title>${image.name}</title>
-                    <link rel="stylesheet" type="text/css" href="${stylesheetURL}" />
-                </head>
+                <!doctype html>
+                <html>
+                    <head>
+                        <title>${image.name}</title>
+                        <link rel="stylesheet" type="text/css" href="${stylesheetURL}" />
+                    </head>
 
-                <body>
-                    <section class="image-wrapper">
-                        <img src="${URL.createObjectURL(image.blob)}" alt="${image.name}" />
-                    </section>
+                    <body>
+                        <section class="image-wrapper">
+                            <img src="${URL.createObjectURL(image.blob)}" alt="${image.name}" />
+                        </section>
 
-                    <!-- SCRIPTS -->
-                    ${scripts}
-                </body>
-            </html>
+                        <!-- SCRIPTS -->
+                        ${scripts}
+                    </body>
+                </html>
             `
 
             const pageHTMLBlob = new Blob([html], { type: 'text/html' })

--- a/src/assets/webpub.js
+++ b/src/assets/webpub.js
@@ -285,7 +285,9 @@ const webpubFromComicBookArchive = async (uri, inputType, layout) => {
             }
 
             body {
-                text-align: center;
+                display: flex;
+                align-items: center;
+                justify-content: center;
             }
         `
     }

--- a/src/assets/webpub.js
+++ b/src/assets/webpub.js
@@ -270,7 +270,7 @@ const webpubFromComicBookArchive = async (uri, inputType, layout) => {
             }
 
             .image-wrapper img {
-                width: 100vw;
+                width: 99vw;
                 max-height: 99.5vh;
                 object-fit: contain;
             }

--- a/src/assets/webpub.js
+++ b/src/assets/webpub.js
@@ -270,7 +270,7 @@ const webpubFromComicBookArchive = async (uri, inputType, layout) => {
             }
 
             .image-wrapper img {
-                width: 99vw;
+                width: 100vw;
                 max-height: 99.5vh;
                 object-fit: contain;
             }


### PR DESCRIPTION
This is a minor change that adds some spacing when displaying CB files on the **Single Column** layout. This should have been included in PR #314, but I didn't notice it because of the frequent implementation changes.

@johnfactotum  @anthonyajumelles If you don't have any suggestions, this is ready to be merged. The change is minor and I don't think it will have any unexpected side effects.

## Single Column
The change makes top and bottom margins relatively equal.
  > The green background is added only to show the difference. It's not part of the change.

## Before
![single-column-current](https://user-images.githubusercontent.com/16267692/81120679-e5395580-8f35-11ea-9de6-7dd5eb5d6ca2.png)

## Updated
![single-column-new](https://user-images.githubusercontent.com/16267692/81120684-e8344600-8f35-11ea-81d2-93c20c70f2ac.png)