### PR TITLE
Add python/python3 to dependency, and PPA for Foliate

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,8 @@ Build-Depends: debhelper, gettext, meson (>= 0.40), pkg-config, libglib2.0-dev (
 
 Package: com.github.johnfactotum.foliate
 Architecture: all
-Depends: gjs (>= 1.52), gir1.2-webkit2-4.0
-Recommends: python (>= 2.7) | python3 (>= 3.4), gir1.2-gspell-1
+Depends: gjs (>= 1.52), gir1.2-webkit2-4.0, python (>= 2.7) | python3 (>= 3.4) 
+Recommends: gir1.2-gspell-1
 Suggests: espeak, festival, dictd, dictd-dictionary, hyphen-af, hyphen-as, hyphen-bg, hyphen-bn, hyphen-ca, hyphen-cs, hyphen-da, hyphen-de, hyphen-el, hyphen-en-ca, hyphen-en-gb, hyphen-en-us, hyphen-es, hyphen-fi, hyphen-fr, hyphen-ga, hyphen-gl, hyphen-gu, hyphen-hi, hyphen-hr, hyphen-hu, hyphen-id, hyphen-is, hyphen-it, hyphen-kn, hyphen-lt, hyphen-lv, hyphen-ml, hyphen-mr, hyphen-nl, hyphen-no, hyphen-or, hyphen-pa, hyphen-pl, hyphen-pt-br, hyphen-pt-pt, hyphen-ro, hyphen-ru, hyphen-show, hyphen-sk, hyphen-sl, hyphen-sr, hyphen-sv, hyphen-ta, hyphen-te, hyphen-uk, hyphen-zu
 Description: Simple and modern eBook viewer.
  A simple and modern GTK eBook viewer, built with GJS and Epub.js.


### PR DESCRIPTION
This would fix the last four lintian errors.

```
$ lintian com.github.johnfactotum.foliate_2.1.1_all.deb 
E: com.github.johnfactotum.foliate: no-copyright-file
W: com.github.johnfactotum.foliate: binary-without-manpage usr/bin/com.github.johnfactotum.Foliate
E: com.github.johnfactotum.foliate: python-script-but-no-python-dep usr/share/com.github.johnfactotum.Foliate/assets/KindleUnpack/compatibility_utils.py #!python
E: com.github.johnfactotum.foliate: python-script-but-no-python-dep usr/share/com.github.johnfactotum.Foliate/assets/KindleUnpack/mobi_split.py #!python
E: com.github.johnfactotum.foliate: python-script-but-no-python-dep usr/share/com.github.johnfactotum.Foliate/assets/KindleUnpack/mobiml2xhtml.py #!/usr/bin/python
E: com.github.johnfactotum.foliate: python-script-but-no-python-dep ... use --no-tag-display-limit to see all (or pipe to a file/program)
```

