### PR TITLE
Update installation instructions in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,17 +207,17 @@ footer a:link, footer a:visited {
         <div class="grid">
             <div>
                 <div>
-                    <h3>Flatpak</h3>
-                    <p><a href="https://flathub.org/apps/details/com.github.johnfactotum.Foliate"><img height="50" alt="Download on Flathub" src="flathub-badge-en.svg"></a></p>
                     <h3>Distribution packages</h3>
                     <p><a href="https://repology.org/project/foliate/versions"><img src="https://repology.org/badge/tiny-repos/foliate.svg" alt="Packaging status"></a></p>
                     <ul>
                         <li>Arch Linux: <a href="https://www.archlinux.org/packages/community/x86_64/foliate/"><code>foliate</code></a></li>
                         <li>Arch Linux (AUR): <a href="https://aur.archlinux.org/packages/foliate-git/"><code>foliate-git</code></a></li>
                         <li>Fedora: <code>sudo dnf install foliate</code></li>
+                        <li>Ubuntu (Stable PPA): <a href="https://launchpad.net/~apandada1/+archive/ubuntu/foliate"><code>foliate</code></a></li>
+                        <li>Ubuntu (Daily builds): <a href="https://launchpad.net/~apandada1/+archive/ubuntu/foliate-daily"><code>com.github.johnfactotum.foliate</code></a></li>
                         <li>Void Linux: <code>xbps-install -S foliate</code></li>
                     </ul>
-                    <p>Debian/Ubuntu packages can be downloaded from the <a href="https://github.com/johnfactotum/foliate/releases">releases</a> page.</p>
+                    <p>Debian/Ubuntu packages can be downloaded from the <a href="https://github.com/johnfactotum/foliate/releases">releases</a> page. Note that it won't update itself. Use the <a href="https://launchpad.net/~apandada1/+archive/ubuntu/foliate">stable ppa</a> listed above to get automatic updates with a traditional package.</p>
                     <h4>Optional dependencies</h4>
                         <ul>
                             <li>To enable auto-hyphenation, you will need to install the hyphenation rules, e.g., <code>hyphen-en</code> for English, <code>hyphen-fr</code> for French, etc.</li>
@@ -229,6 +229,10 @@ footer a:link, footer a:visited {
             </div>
             <div>
                 <div>
+                    <h3>Flatpak</h3>
+                    <p><a href="https://flathub.org/apps/details/com.github.johnfactotum.Foliate"><img height="50" alt="Download on Flathub" src="flathub-badge-en.svg"></a></p>
+                    <h3>Snap Store</h3>
+                    <a href="https://snapcraft.io/foliate"><img height="50" alt="Get it from the Snap Store" src="snap-badge.svg"></a>
                     <h3>Manual Installation from Source</h3>
                     <ol>
                         <li>Clone the source code from <a href="https://github.com/johnfactotum/foliate.git">GitHub</a> or download one of the <a href="https://github.com/johnfactotum/foliate/releases">releases</a>.</li>

--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@ footer a:link, footer a:visited {
                         <li>Ubuntu (Daily builds): <a href="https://launchpad.net/~apandada1/+archive/ubuntu/foliate-daily"><code>com.github.johnfactotum.foliate</code></a></li>
                         <li>Void Linux: <code>xbps-install -S foliate</code></li>
                     </ul>
-                    <p>Debian/Ubuntu packages can be downloaded from the <a href="https://github.com/johnfactotum/foliate/releases">releases</a> page. Note that it won't update itself. Use the <a href="https://launchpad.net/~apandada1/+archive/ubuntu/foliate">stable ppa</a> listed above to get automatic updates with a traditional package.</p>
+                    <p>Debian/Ubuntu packages can be downloaded from the <a href="https://github.com/johnfactotum/foliate/releases">releases</a> page. However, if you use this method, it won't update itself, you'll have to manually check whether a new version has been released.</p>
                     <h4>Optional dependencies</h4>
                         <ul>
                             <li>To enable auto-hyphenation, you will need to install the hyphenation rules, e.g., <code>hyphen-en</code> for English, <code>hyphen-fr</code> for French, etc.</li>


### PR DESCRIPTION
I have added the installation instructions in the website, and added Snap Store (which was missing in the installation instructions) as well. I also moved Flatpak and Snap to the right column to balance the length of the two columns
Here's how it looks now.
![foliate](https://user-images.githubusercontent.com/3063132/82113664-3a037a00-9747-11ea-98cc-20e531c70f04.png)
