### PR TITLE
Fix GInotifyFileMonitor crash, fixes #357

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -208,6 +208,7 @@ var Storage = GObject.registerClass({
         this.indent = indent
         this._file = Gio.File.new_for_path(path)
         this._data = this._read()
+        /* File Monitoring is currently broken: https://gitlab.gnome.org/GNOME/gjs/-/issues/297
         this._monitor = this._file.monitor(Gio.FileMonitorFlags.NONE, null)
         this._monitor.connect('changed', () => {
             if (this._getModified() > this._modified) {
@@ -216,6 +217,7 @@ var Storage = GObject.registerClass({
                 this.emit('externally-modified')
             }
         })
+        */
         this._debouncedWrite = debounce(this._write.bind(this), 1000)
     }
     static getPath(type, key, ext = '.json') {


### PR DESCRIPTION
Gio.FileMonitor has a bug that causes random GJS crashes when file is monitored for changes. The bug has been reported to the GJS devs but the cause is unknown and is still marked as unresolved. This commit fixes random foliate crashes by commenting out (disabling) file monitoring functionality until GJS bug is resolved.