### PR TITLE
Fix Standard Ebooks OPDS link in catalog.js

### DIFF
--- a/src/catalogs.js
+++ b/src/catalogs.js
@@ -19,7 +19,7 @@ const { Storage } = imports.utils
 const defaultCatalogs = [
     {
         title: 'Standard Ebooks',
-        uri: 'https://standardebooks.org/opds/all',
+        uri: 'https://standardebooks.org/opds',
         preview: 'https://standardebooks.org/opds/all',
     },
     {


### PR DESCRIPTION
The URI points to the OPDS list of all ebooks, instead of pointing to the OPDS index. While the index currently only has one item ("all"), it may get new items in the future, like browse by tag or by most popular.