### PR TITLE
[Bug Fix] Do not use Wiktionary header as "language"

### DIFF
--- a/src/lookup.js
+++ b/src/lookup.js
@@ -128,10 +128,10 @@ const wiktionary = (word, language, lookupFunc) => lookup(
             if (internalLink && wikiNamespaces.every(namespace =>
                 !internalLink.startsWith(namespace + ':')
                 && !internalLink.startsWith(namespace + '_talk:'))) {
-                const [title, lang] = internalLink.split('#')
+                const [title] = internalLink.split('#')
                 const word = decodeURIComponent(title)
                     .replace(/_/g, ' ')
-                lookupFunc(word, lang || 'en')
+                lookupFunc(word, language)
                 return true
             }
         }


### PR DESCRIPTION
# Context

As shown in the recording below, some of the internal links do not work.
![foliate_bug_past_tense](https://user-images.githubusercontent.com/12106903/88202130-47345d80-cbfd-11ea-98b0-9ca38d89f753.gif)

# Investigation
I found that some of the internal links look like `https://en.wiktionary.org/wiki/tell#English`. As a result, the statement below will evaluate

```
internalLink.split('#') // => 'tell', 'English'
```

Since "English" is not a valid locale, `lookupFunc('tell', 'English')` will fail.