### PR TITLE
OPDS: Remember credentials

### DIFF
--- a/src/opds.js
+++ b/src/opds.js
@@ -554,7 +554,7 @@ var OpdsClient = class OpdsClient {
         const widget = this._widget
         const toplevel = widget instanceof Gtk.Widget
             ? widget.get_toplevel() : null
-        return promptAuthenticate(req, toplevel)
+        return promptAuthenticate(req, this.username, this.password, toplevel)
     }
     static opdsEntryToMetadata(entry, showSummary = true) {
         const {

--- a/src/opds.js
+++ b/src/opds.js
@@ -554,7 +554,7 @@ var OpdsClient = class OpdsClient {
         const widget = this._widget
         const toplevel = widget instanceof Gtk.Widget
             ? widget.get_toplevel() : null
-        return promptAuthenticate(req, this.username, this.password, toplevel)
+        return promptAuthenticate(req, toplevel)
     }
     static opdsEntryToMetadata(entry, showSummary = true) {
         const {

--- a/src/utils.js
+++ b/src/utils.js
@@ -738,13 +738,13 @@ var sepHeaderFunc = row => {
     if (row.get_index()) row.set_header(new Gtk.Separator())
 }
 
-var promptAuthenticate = (req, username, password, toplevel) => {
-    if (username) {
-        const cred = new WebKit2.Credential(username, password,
-            WebKit2.CredentialPersistence.FOR_SESSION)
-        req.authenticate(cred)
+var promptAuthenticate = (req, toplevel) => {
+    const storedCred = req.get_proposed_credential()
+    if (storedCred && !req.is_retry()) {
+        req.authenticate(storedCred)
         return true
     }
+
     const msg = new Gtk.MessageDialog({
         text: _('Authentication Required'),
         secondary_text:
@@ -776,6 +776,9 @@ var promptAuthenticate = (req, username, password, toplevel) => {
         xalign: 1,
         label: _('Password')
     })
+    const rCheckButton = new Gtk.CheckButton({
+        label: _('Remember my credentials')
+    })
     uLabel.get_style_context().add_class('dim-label')
     pLabel.get_style_context().add_class('dim-label')
     const uEntry = new Gtk.Entry()
@@ -783,10 +786,18 @@ var promptAuthenticate = (req, username, password, toplevel) => {
         visibility: false,
         input_purpose: Gtk.InputPurpose.PASSWORD
     })
+
+    if (storedCred) {
+        uEntry.text = storedCred.get_username()
+        pEntry.text = storedCred.get_password()
+        rCheckButton.set_active(true)
+    }
+
     grid.attach(uLabel, 0, 0, 1, 1)
     grid.attach(uEntry, 1, 0, 1, 1)
     grid.attach(pLabel, 0, 1, 1, 1)
     grid.attach(pEntry, 1, 1, 1, 1)
+    grid.attach(rCheckButton, 1, 2, 1, 1)
     grid.show_all()
     msg.message_area.pack_start(grid, false, true, 0)
 
@@ -797,7 +808,9 @@ var promptAuthenticate = (req, username, password, toplevel) => {
 
     if (msg.run() === Gtk.ResponseType.OK) {
         const cred = new WebKit2.Credential(uEntry.text, pEntry.text,
-            WebKit2.CredentialPersistence.FOR_SESSION)
+            rCheckButton.get_active()
+                ? WebKit2.CredentialPersistence.PERMANENT
+                : WebKit2.CredentialPersistence.FOR_SESSION)
         req.authenticate(cred)
     } else req.cancel()
 
@@ -814,7 +827,7 @@ var downloadWithWebKit = (uri, decideDestination, onProgress, token, toplevel) =
             })
         })
         webView.connect('authenticate', (webview, req) =>
-            promptAuthenticate(req, null, null, toplevel))
+            promptAuthenticate(req, toplevel))
 
         const webContext = WebKit2.WebContext.get_default()
         const connection = webContext.connect('download-started', (ctx, download) => {


### PR DESCRIPTION
Currently Foliate forgets OPDS credentials when the program exits, and prompts them again on next start, which is quite annoying, especially if you have a long password to type. This PR implements remembering of those credentials. 

Changes:
- Add "Remember my credentials" checkbox to the auth dialog. When checked it stores username and password to Secret Service. Checkbox is toggled by default if the credentials exist in Secret Service. Unchecking the checkbox lets user to use alternative credentials temporarily without affecting the stored credentials. To permanently remove stored credentials, user must remove them from the Secret Service using e.g. Seahorse.

I have tested this against my own COPS service I'm running on my NAS along along with Calibre's database, and it seems to work fine. Are there any corner cases that could break because of this that I should check?

Auth dialog:
![auth-dialog](https://user-images.githubusercontent.com/1950698/90767257-8ede0000-e2f5-11ea-8b33-65a4773a031a.png)

Deleting credentials from Seahorse:
![seahorse](https://user-images.githubusercontent.com/1950698/90767309-a87f4780-e2f5-11ea-9e4a-3a7ffc50f953.png)
