### PR TITLE
Make debian package compatible with Ubuntu 18.04 and Ubuntu 20.04

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: com.github.johnfactotum.foliate
 Section: gnome
 Priority: optional
 Maintainer: John Factotum <50942278+johnfactotum@users.noreply.github.com>
-Build-Depends: debhelper-compat(=13),
+Build-Depends: debhelper-compat(=10),
 	gettext,
 	meson (>= 0.40),
 	pkg-config,

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
The current source did not build in Ubuntu 18.04 or Ubuntu 20.04 due to missing dependency (`debhelper-compat`). This pull request fixes it.

Also, I changed the format `quilt` to `native`, to save hassle for the upstream developer. Otherwise, one would need to create a "upstream tarball" for Debian packaging.

I have given more details in the commit messages of https://github.com/johnfactotum/foliate/commit/dd4d382e9e456b3b4bf4c2d2daca3dfd26cc0f87 and https://github.com/johnfactotum/foliate/commit/ce5496b641f4bc45810315cc19685ce462d724fe