### PR TITLE
Handle touchscreen events with Gtk.GestureSwipe

### DIFF
--- a/src/epubView.js
+++ b/src/epubView.js
@@ -641,6 +641,17 @@ var EpubView = GObject.registerClass({
                     } else if (velocityX < -SWIPE_SENSIVITY) {
                         this.goRight()
                     }
+                } else {
+                    // disable swipe up/down with non-paginated layouts (scrolled,
+                    // continuous), this protects against accidental switches if
+                    // user pans the page too fast
+                    if (!this.isPaginated) return
+
+                    if (velocityY > SWIPE_SENSIVITY) {
+                        this.prev()
+                    } else if (velocityY < -SWIPE_SENSIVITY) {
+                        this.next()
+                    }
                 }
             } catch (e) {
                 logError(e)

--- a/src/epubView.js
+++ b/src/epubView.js
@@ -628,13 +628,22 @@ var EpubView = GObject.registerClass({
         this._swipeGesture = new Gtk.GestureSwipe({ widget: this._webView })
         this._swipeGesture.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
         this._swipeGesture.set_touch_only(true)
-        this._swipeGesture.connect('swipe', (_, velocity_x, velocity_y) => {
-            if (Math.abs(velocity_y) < SWIPE_SENSIVITY) {
-                if (velocity_x > SWIPE_SENSIVITY) {
-                    this.goLeft()
-                } else if (velocity_x < -SWIPE_SENSIVITY) {
-                    this.goRight()
+        this._swipeGesture.connect('swipe', async (_, velocityX, velocityY) => {
+            try {
+                // do not switch to another page if the page has been pinch zoomed,
+                // this protects against accidental switches if user pans the page
+                // too fast
+                if (await this.getWindowIsZoomed()) return
+                // switch to another page if swipe was fast enough
+                if (Math.abs(velocityY) < SWIPE_SENSIVITY) {
+                    if (velocityX > SWIPE_SENSIVITY) {
+                        this.goLeft()
+                    } else if (velocityX < -SWIPE_SENSIVITY) {
+                        this.goRight()
+                    }
                 }
+            } catch (e) {
+                logError(e)
             }
         })
 

--- a/src/epubView.js
+++ b/src/epubView.js
@@ -636,21 +636,29 @@ var EpubView = GObject.registerClass({
                 if (await this.getWindowIsZoomed()) return
                 // switch to another page if swipe was fast enough
                 if (Math.abs(velocityY) < SWIPE_SENSIVITY) {
-                    if (velocityX > SWIPE_SENSIVITY) {
-                        this.goLeft()
-                    } else if (velocityX < -SWIPE_SENSIVITY) {
-                        this.goRight()
+                    // allow swipe to left/right with paginated and scrolled
+                    // layouts but not with continuous layout, as changing page
+                    // within continuous layout would just scroll the page by
+                    // the height of the screen and that is not very intuitive
+                    // to use
+                    if (this.isPaginated || this.isScrolled) {
+                        if (velocityX > SWIPE_SENSIVITY) {
+                            this.goLeft()
+                        } else if (velocityX < -SWIPE_SENSIVITY) {
+                            this.goRight()
+                        }
                     }
                 } else {
-                    // disable swipe up/down with non-paginated layouts (scrolled,
-                    // continuous), this protects against accidental switches if
-                    // user pans the page too fast
-                    if (!this.isPaginated) return
-
-                    if (velocityY > SWIPE_SENSIVITY) {
-                        this.prev()
-                    } else if (velocityY < -SWIPE_SENSIVITY) {
-                        this.next()
+                    // allow swipe up/down with paginated layouts, and disable
+                    // for non-paginated layouts (scrolled, continuous), this
+                    // protects against accidental switches if user pans the
+                    // page too fast
+                    if (this.isPaginated) {
+                        if (velocityY > SWIPE_SENSIVITY) {
+                            this.prev()
+                        } else if (velocityY < -SWIPE_SENSIVITY) {
+                            this.next()
+                        }
                     }
                 }
             } catch (e) {
@@ -1272,6 +1280,9 @@ var EpubView = GObject.registerClass({
     }
     get isPaginated() {
         return layouts[this.settings.layout].options.flow === 'paginated'
+    }
+    get isScrolled() {
+        return layouts[this.settings.layout].options.flow === 'scrolled-doc'
     }
     get widget() {
         return this._webView

--- a/src/web/epub-viewer.js
+++ b/src/web/epub-viewer.js
@@ -797,21 +797,6 @@ const setupRendition = () => {
     document.addEventListener('keydown', handleKeydown, false)
 
     if (paginated) {
-        // scroll through pages
-        const onwheel = debounce(event => {
-            if (getWindowIsZoomed()) return
-            const { deltaX, deltaY } = event
-            if (Math.abs(deltaX) > Math.abs(deltaY)) {
-                if (deltaX > 0) goRight()
-                else if (deltaX < 0) goLeft()
-            } else {
-                if (deltaY > 0) rendition.next()
-                else if (deltaY < 0) rendition.prev()
-            }
-            event.preventDefault()
-        }, 100, true)
-        document.documentElement.onwheel = onwheel
-
         // go to the next page when selecting to the end of a page
         // this makes it possible to select across pages
         rendition.on('selected', debounce(cfiRange => {

--- a/src/window.js
+++ b/src/window.js
@@ -1018,14 +1018,9 @@ var Window = GObject.registerClass({
                     this._autoHideHeaderBar.alwaysReveal(visible)
             }
             if (!epub.isPaginated) return toggleControls()
-
-            const rtl = epub.metadata.direction === 'rtl'
-            const goRight = () => rtl ? epub.prev() : epub.next()
-            const goLeft = () => rtl ? epub.next() : epub.prev()
-
             const place = position / width
-            if (place > 2/3) goRight()
-            else if (place < 1/3) goLeft()
+            if (place > 2/3) epub.goRight()
+            else if (place < 1/3) epub.goLeft()
             else toggleControls()
         })
         this._epub.connect('book-displayed', () => this.loading = false)


### PR DESCRIPTION
Implements better touchscreen event handling. Swipe gesture detection is done with [Gtk.GestureSwipe](https://gjs-docs.gnome.org/gtk30~3.24.22/gtk.gestureswipe) instead of relying on webkit's wheel event. Moved wheel event handler from webkit page to GJS side, as there was no way to filter out touchscreen originating events within webkit. Implementation is based on discussion in #232 