### PR TITLE
Fix launchpad build failure - add appstream to Build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends: debhelper-compat(=10),
 	meson (>= 0.40),
 	pkg-config,
 	libglib2.0-dev (>= 2.54),
-	gjs
+	gjs,
+	appstream
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://johnfactotum.github.io/foliate/


### PR DESCRIPTION
Without appstream, the build was [failing](https://launchpadlibrarian.net/539281661/buildlog_ubuntu-focal-amd64.com.github.johnfactotum.foliate_2.6.3-3+dev~202105180302~ubuntu20.04.1_BUILDING.txt.gz) in Launchpad (after commit https://github.com/johnfactotum/foliate/commit/3bf0d63d138e4a6aed340a0d39b763203c03c56b), with the following error.

```
Found ninja-1.10.0 at /usr/bin/ninja
   dh_auto_build
	cd obj-x86_64-linux-gnu && LC_ALL=C.UTF-8 ninja -j4 -v
[1/4] glib-compile-resources ../src/com.github.johnfactotum.Foliate.data.gresource.xml --sourcedir ../src --internal --generate --target src/com.github.johnfactotum.Foliate.data.gresource --dependency-file src/com.github.johnfactotum.Foliate.data.gresource.d
[2/4] glib-compile-resources ../src/com.github.johnfactotum.Foliate.src.gresource.xml --sourcedir src --sourcedir ../src --internal --generate --target src/com.github.johnfactotum.Foliate.src.gresource --dependency-file src/com.github.johnfactotum.Foliate.src.gresource.d
[3/4] /usr/bin/meson --internal msgfmthelper ../data/com.github.johnfactotum.Foliate.metainfo.xml.in data/com.github.johnfactotum.Foliate.metainfo.xml xml ../data/../po
FAILED: data/com.github.johnfactotum.Foliate.metainfo.xml 
/usr/bin/meson --internal msgfmthelper ../data/com.github.johnfactotum.Foliate.metainfo.xml.in data/com.github.johnfactotum.Foliate.metainfo.xml xml ../data/../po
msgfmt: cannot locate ITS rules for ../data/com.github.johnfactotum.Foliate.metainfo.xml.in
[4/4] /usr/bin/meson --internal msgfmthelper ../data/com.github.johnfactotum.Foliate.desktop.in data/com.github.johnfactotum.Foliate.desktop desktop ../data/../po
ninja: build stopped: subcommand failed.
dh_auto_build: error: cd obj-x86_64-linux-gnu && LC_ALL=C.UTF-8 ninja -j4 -v returned exit code 1
make: *** [debian/rules:6: binary] Error 25
dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
```

I encountered a similar error while packaging [blanket](https://github.com/rafaelmardojai/blanket), and I [came to know](https://answers.launchpad.net/launchpad/+question/692788) that `appstream` fixes it.

The launchpad build [was successful](https://code.launchpad.net/~apandada1/+archive/ubuntu/foliate-daily/+build/21565026) after adding `appstream` to build depednds.
