### PR TITLE
Add shortcut to get back to the library

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -329,6 +329,7 @@ function main(argv) {
             ['app.quit', ['<ctrl>q']],
             ['app.open', ['<ctrl>o']],
             ['app.preferences', ['<ctrl>comma']],
+            ['app.library', ['<ctrl>h']],
 
             ['lib.list-view', ['<ctrl>1']],
             ['lib.grid-view', ['<ctrl>2']],

--- a/src/ui/shortcutsWindow.ui
+++ b/src/ui/shortcutsWindow.ui
@@ -131,6 +131,13 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
+                <property name="title" translatable="yes">Library</property>
+                <property name="action-name">app.library</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="visible">True</property>
                 <property name="title" translatable="yes">Close current window</property>
                 <property name="action-name">win.close</property>
               </object>


### PR DESCRIPTION
Fix #656

I used Ctrl+H since Escape (suggested in #631 was already in use to get out of Fullscreen. I'm using this locally and it seems to be working, but first contrib so let me know if I'm missing something.