### PR TITLE
Stop unescaping entities on pango markup

### DIFF
--- a/src/web/utils.js
+++ b/src/web/utils.js
@@ -118,5 +118,5 @@ const toPangoMarkup = (html, baseURL = '') => {
         })
         if (nodeName === 'a' && !el.hasAttribute('href')) usurp(el)
     })
-    return unescapeHTML(doc.body.innerHTML.trim()).replace(/&/g, '&amp;')
+    return unescapeHTML(doc.body.innerHTML.replace(/&lt;/g, '&amp;lt;').trim()).replace(/&/g, '&amp;')
 }


### PR DESCRIPTION
Fixes #799

After the changes, footnotes with "<" in them show up fine in the preview:

![2021-10-16-16:10:52](https://user-images.githubusercontent.com/1296511/137590753-f5b7a076-c641-4638-8f29-ebdef2653a73.png)

I'd appreciate a review @johnfactotum since this is partially a revert of fc8f972