### PR TITLE
Specify WebKit version to be used

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,8 @@ pkg.initGettext()
 pkg.initFormat()
 pkg.require({
     'Gio': '2.0',
-    'Gtk': '3.0'
+    'Gtk': '3.0',
+    'WebKit2': '4.0'
 })
 
 const { Gio, Gtk, Gdk, GLib, WebKit2 } = imports.gi


### PR DESCRIPTION
WebKit exists in multiple versions, namely:
4.0: Gtk 3 / LibSoup 2
4.1: Gtk 3 / Libsoup 3
5.0: Gtk 4 / Libsoup 3

If a user happens to have the GTK 4 variant installed, foliate fails to launch:

(com.github.johnfactotum.Foliate:25683): Gjs-CRITICAL **: 20:25:28.434: JS ERROR: Error: Requiring WebKit2, version none: Requiring namespace 'Gtk' version '4.0', but '3.0' is already loaded
@resource:///com/github/johnfactotum/Foliate/js/main.js:23:42
@/usr/bin/foliate:9:1

Pin foliate to WebKit 2 - 4.0 to circumvent this (4.1 could possibly work, but I doubt any testing was done with Soup 3 so far)

Originally reported downstream at https://bugzilla.opensuse.org/show_bug.cgi?id=1192627
