### PR TITLE
Fix problem of saving custom themes

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -86,12 +86,12 @@ var Theme = GObject.registerClass({
 }, class Theme extends GObject.Object {
     toJSON() {
         return {
-            'theme-name': this['theme-name'],
-            'fg-color': this['fg-color'],
-            'bg-color': this['bg-color'],
-            'link-color': this['link-color'],
+            'theme-name': this.theme_name,
+            'fg-color': this.fg_color,
+            'bg-color': this.bg_color,
+            'link-color': this.link_color,
             invert: this.invert,
-            'dark-mode': this['dark-mode']
+            'dark-mode': this.dark_mode
         }
     }
 })


### PR DESCRIPTION
Fixes #838

Previously, no properties of the custom theme were saved/exported to **themes.json** except `invert`. Hence, Foliate rendered the custom themes as blank items without names as seen in issue #838. This is what causes the problem described in said issue.

This PR aims to solve the problem of exporting the custom theme properties to **themes.json** which as a result will fix the issue (#838).

---

When trying to find the cause of the issue, I was wondering as to what data is saved to Foliate's config file(s) when adding a custom theme.

Here's what I found in `~/.config/com.github.johnfactotum.Foliate/themes.json`:
```json
{
  "themes": [
    {
      "invert": false
    }
  ]
}
```

It seems like the only property of the custom theme saved is the `invert` property.

And it is confirmed when another custom theme is added.
```json
{
  "themes": [
    {
      "invert": false
    },
    {
      "invert": false
    }
  ]
}
```

---

**themes.json** after the patch (an example of the expected result):
```json
{
  "themes": [
    {
      "theme-name": "Mint",
      "fg-color": "black",
      "bg-color": "white",
      "link-color": "rgb(6,154,154)",
      "invert": false,
      "dark-mode": false
    }
  ]
}
```