### PR TITLE
Improve URI handling

### DIFF
--- a/src/epubView.js
+++ b/src/epubView.js
@@ -869,7 +869,7 @@ var EpubView = GObject.registerClass({
                 this._enableDevtools = this.settings.enable_devtools
                 this._autohideCursor = this.settings.autohide_cursor
 
-                let uri = this._uri;
+                let uri = this._uri
                 const filename = this._file.get_basename().replace(/\.[^\s.]+$/, '')
 
                 // Resolve non-file URIs, if possible. This enables support for certain network 

--- a/src/epubView.js
+++ b/src/epubView.js
@@ -869,8 +869,14 @@ var EpubView = GObject.registerClass({
                 this._enableDevtools = this.settings.enable_devtools
                 this._autohideCursor = this.settings.autohide_cursor
 
-                const uri = this._uri
+                let uri = this._uri;
                 const filename = this._file.get_basename().replace(/\.[^\s.]+$/, '')
+
+                // Resolve non-file URIs, if possible. This enables support for certain network 
+                // mounted filesystems that WebKit may not know how to resolve. 
+                if (!this._file.has_uri_scheme("file") && this._file.get_path() != null) {
+                    uri = `file://${this._file.get_path()}`
+                }
 
                 const options = layouts[this.settings.layout].options
 


### PR DESCRIPTION
When opening files located in certain network mounted filesystems (like Google Drive, for instance), the URI of the file object may be of a scheme that the file handling code in the WebKit instance can't resolve correctly (e.g. `google-drive://[...]@gmail.com/0AAdJafqLG0cbUk9PVA/1AeV9EdpVnPTqWabZNZ9wNbSuGyPWwH16/1lrBJ9SWpFm_eIaFnVrllWTfSedr5CcIW`).

![image](https://user-images.githubusercontent.com/1475410/155006169-182df5f9-898d-4c28-8f89-cc08fe46d723.png)

```
(com.github.johnfactotum.Foliate:11859): Gjs-WARNING **: 09:55:19.652: JS ERROR: Error: Empty Response
_init/<@resource:///com/github/johnfactotum/Foliate/js/epubView.js:623:57
_handleAction@resource:///com/github/johnfactotum/Foliate/js/epubView.js:886:22
_init/<@resource:///com/github/johnfactotum/Foliate/js/epubView.js:617:18
main@resource:///com/github/johnfactotum/Foliate/js/main.js:478:24
run@resource:///org/gnome/gjs/modules/script/package.js:206:19
@/usr/bin/com.github.johnfactotum.Foliate:9:17
```

This change attempts to fix that by resolving non-file URIs to a local path (if possible) and sending that down instead. 