### PR TITLE
Fix "zoom" translation to spanish.

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -946,17 +946,17 @@ msgstr "Guardar como"
 #: src/ui/shortcutsWindow.ui:198 src/ui/shortcutsWindow.ui:320
 #: src/ui/shortcutsWindow.ui:383
 msgid "Zoom out"
-msgstr "Reducir el zum"
+msgstr "Alejar"
 
 #: src/ui/imageViewer.ui:139 src/ui/mainMenu.ui:64
 msgid "Restore zoom"
-msgstr "Restaurar el zum"
+msgstr "Restaurar el nivel de aumento"
 
 #: src/ui/imageViewer.ui:152 src/ui/mainMenu.ui:73
 #: src/ui/shortcutsWindow.ui:190 src/ui/shortcutsWindow.ui:313
 #: src/ui/shortcutsWindow.ui:375
 msgid "Zoom in"
-msgstr "Aumentar el zum"
+msgstr "Acercar"
 
 #: src/ui/imageViewer.ui:184 src/ui/shortcutsWindow.ui:399
 msgid "Rotate 90° counter-clockwise"
@@ -1270,15 +1270,15 @@ msgstr "Activa la pantalla completa"
 
 #: src/ui/menuBar.ui:94
 msgid "Zoom In"
-msgstr "Aumentar el zum"
+msgstr "Acercar"
 
 #: src/ui/menuBar.ui:98
 msgid "Restore Zoom"
-msgstr "Restaurar el zum"
+msgstr "Restaurar el nivel de aumento"
 
 #: src/ui/menuBar.ui:102
 msgid "Zoom Out"
-msgstr "Reducir el zum"
+msgstr "Alejar"
 
 #: src/ui/menuBar.ui:116
 msgid "Up to Two Columns"
@@ -1620,7 +1620,7 @@ msgstr "Iniciar/detener el texto a voz"
 
 #: src/ui/shortcutsWindow.ui:206 src/ui/shortcutsWindow.ui:391
 msgid "Restore zoom level"
-msgstr "Restaurar el nivel de zum"
+msgstr "Restaurar el nivel de aumento"
 
 #: src/ui/shortcutsWindow.ui:214
 msgid "Toggle fullscreen"
@@ -3566,8 +3566,8 @@ msgstr ""
 "real"
 
 #: data/com.github.johnfactotum.Foliate.metainfo.xml.in:243
-msgid "Ability to zoom in and zoom out"
-msgstr "Capacidad para ampliar y reducir el zum"
+msgid "Ability to zoom in and aumento out"
+msgstr "Capacidad para ampliar y reducir el aumento"
 
 #: data/com.github.johnfactotum.Foliate.metainfo.xml.in:244
 msgid "Improved image viewer with \"save as\" option"
@@ -3706,7 +3706,7 @@ msgstr ""
 
 #: data/com.github.johnfactotum.Foliate.metainfo.xml.in:298
 msgid "Fixed not being able to zoom images with Kindle books"
-msgstr "Corregido el no poder hacer zum a imágenes con libros de Kindle"
+msgstr "Corregido el no poder hacer aumento a imágenes con libros de Kindle"
 
 #: data/com.github.johnfactotum.Foliate.metainfo.xml.in:299
 msgid "Fixed not being able to open books with .epub3 filename extension"
@@ -3790,7 +3790,7 @@ msgstr ""
 
 #: data/com.github.johnfactotum.Foliate.metainfo.xml.in:354
 msgid "Ability to zoom and copy images"
-msgstr "Capacidad para hacer zum de imágenes y copiarlas"
+msgstr "Capacidad para hacer aumento en imágenes y copiarlas"
 
 #: data/com.github.johnfactotum.Foliate.metainfo.xml.in:355
 msgid "Option to auto-hide cursor"
@@ -4037,7 +4037,7 @@ msgstr ""
 #: data/com.github.johnfactotum.Foliate.gschema.xml:121
 #: data/com.github.johnfactotum.Foliate.gschema.xml:122
 msgid "Zoom level"
-msgstr "Nivel de zum"
+msgstr "Nivel de aumento"
 
 #: data/com.github.johnfactotum.Foliate.gschema.xml:132
 msgid "Line-height"


### PR DESCRIPTION
The word "zum" is an "anglisismo" and can be improved changing it with another better translations.

Almost the time it is rare to read "zum", it is even better to read it in English and of course, have better ways to say it without use an "anglisismo".

Sorry for use "anglisismo", idk how to say it on english.