### PR TITLE
Add StartupNotify to desktop file

### DIFF
--- a/data/com.github.johnfactotum.Foliate.desktop.in
+++ b/data/com.github.johnfactotum.Foliate.desktop.in
@@ -13,6 +13,7 @@ Keywords=Ebook;Book;EPUB;Viewer;Reader;
 Actions=new-window;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
+StartupNotify=true
 
 [Desktop Action new-window]
 Name=Library


### PR DESCRIPTION
GTK apps have built-in support for this, and it allows shells like
Phosh to show a splash screen while Foliate is starting.

Reference: https://developer-old.gnome.org/integration-guide/stable/startup-notification.html.en