### PR TITLE
Update SDK Runtime

### DIFF
--- a/com.github.johnfactotum.Foliate.json
+++ b/com.github.johnfactotum.Foliate.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.johnfactotum.Foliate",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.johnfactotum.Foliate",
     "finish-args": [


### PR DESCRIPTION
GNOME runtimes 40 and 41 reached the end of life.