### PR TITLE
Publishing installation via pacstall

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,6 +328,12 @@ pre {
                     </td>
                 </tr>
                 <tr>
+                    <td>Ubuntu (Pacstall)</td>
+                    <td>
+                        <a href="https://pacstall.dev/packages/foliate-deb">pacstall -I foliate-deb</a>
+                    </td>
+                </tr>
+                <tr>
                     <td><img src="icons/distributor-logo-void.svg" class="distro-icon"></td>
                     <td>Void Linux</td>
                     <td><code>xbps-install -S <a href="https://github.com/void-linux/void-packages/tree/master/srcpkgs/foliate">foliate</a></code></td>


### PR DESCRIPTION
As requested, an example of how to install the package using Pacstall has been added.

I did the PR directly on gb-pages, as I couldn't find the other source (if any) to change the site's public content.

The package is not yet published on pacstall, as we were waiting for your release.

I will be requesting its publication shortly after this PR.

<https://github.com/johnfactotum/foliate/issues/1041>
<https://github.com/pacstall/pacstall-programs/pull/3660>