### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Read books in style.
 - `gjs` (>= 1.72)
 - `gtk4` (>= 4.10)
 - `libadwaita` (`gir1.2-adw-1` in Debian-based distros)
-- `webkitgtk-6.0` (`gir1.2-webkit-6.0` in Debian-based distros)
+- `webkitgtk6.0` (`gir1.2-webkit-6.0` in Debian-based distros)
 
 #### Optional Dependencies
 


### PR DESCRIPTION
In Fedora-based distros. All the package mentioned is correct, but the webkitgtk.

In Fedora, it is `webkitgtk6-0`. Or should I mention both Fedora and Debian dependencies?