### PR TITLE
Add Annotation Marks

### DIFF
--- a/src/annotations.js
+++ b/src/annotations.js
@@ -14,6 +14,8 @@ const Bookmark = utils.makeDataClass('FoliateBookmark', {
 
 const Annotation = utils.makeDataClass('FoliateAnnotation', {
     'value': 'string',
+    'location': 'int',
+    'total': 'int',
     'color': 'string',
     'text': 'string',
     'note': 'string',

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -819,6 +819,8 @@ export const BookViewer = GObject.registerClass({
                     const annotation = this.#data.annotations.get(value)
                     this.#data.addAnnotation(annotation ?? {
                         value, text,
+                        location: this.#data.storage.get('progress')[0],
+                        total: this.#data.storage.get('progress')[1],
                         color: this.highlight_color,
                         created: new Date().toISOString(),
                     }).then(() => resolve('highlight'))

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -751,7 +751,7 @@ export const BookViewer = GObject.registerClass({
         if (identifier) {
             this.#data = await dataStore.get(identifier, this._view)
             const { annotations, bookmarks } = this.#data
-            this._navbar.loadAnnotations(annotations.export())
+            this._navbar.loadAnnotations(annotations.export(), book)
             this._annotation_view.setupModel(annotations)
             this._bookmark_view.setupModel(bookmarks)
             const updateAnnotations = () => this._annotation_stack

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -751,6 +751,7 @@ export const BookViewer = GObject.registerClass({
         if (identifier) {
             this.#data = await dataStore.get(identifier, this._view)
             const { annotations, bookmarks } = this.#data
+            this._navbar.loadAnnotations(annotations.export())
             this._annotation_view.setupModel(annotations)
             this._bookmark_view.setupModel(bookmarks)
             const updateAnnotations = () => this._annotation_stack

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -109,27 +109,18 @@ GObject.registerClass({
         const sizes = sections.filter(s => s.linear !== 'no').map(s => s.size)
         if (sizes.length > 100) return
         const total = sizes.reduce((a, b) => a + b, 0)
-        let i = 0
         let sum = 0
-        let sums = [0]
         for (const size of sizes.slice(0, -1)) {
             sum += size
-            sums.push(sum)
             // add epsilon so it will snap to section start
             const fraction = sum / total + Number.EPSILON
             this.add_mark(fraction, Gtk.PositionType.TOP, null)
-            i += 1
         }
         for (const annotation of annotations) {
-            const parts = CFI.parse(annotation.value)
-            // console.log(annotation.value)
-            // console.log('parts', parts.start)
-            const index = CFI.fake.toIndex((parts.parent ?? parts).shift())
-            // const indexStart = parts.start[0][0].index
-            // const offsetStart = parts.start[0][0].offset
-            // console.log(parts.start[0][0], index, indexStart, offsetStart)
-            const fraction = sums[index]/total // + indexStart*512/total + offsetStart/total
-            this.add_mark(fraction, Gtk.PositionType.BOTTOM, null)
+            if (annotation.location) {
+                const fraction = annotation.location / annotation.total + Number.EPSILON
+                this.add_mark(fraction, Gtk.PositionType.BOTTOM, null)
+            }
         } 
     }
     update(fraction) {

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -4,7 +4,6 @@ import Pango from 'gi://Pango'
 import * as utils from './utils.js'
 import * as format from './format.js'
 import './tts.js'
-import * as CFI from './foliate-js/epubcfi.js'
 
 const Landmark = utils.makeDataClass('FoliateLandmark', {
     'label': 'string',

--- a/src/navbar.js
+++ b/src/navbar.js
@@ -4,6 +4,7 @@ import Pango from 'gi://Pango'
 import * as utils from './utils.js'
 import * as format from './format.js'
 import './tts.js'
+import * as CFI from './foliate-js/epubcfi.js'
 
 const Landmark = utils.makeDataClass('FoliateLandmark', {
     'label': 'string',
@@ -114,6 +115,24 @@ GObject.registerClass({
             this.add_mark(fraction, Gtk.PositionType.TOP, null)
         }
     }
+    loadAnnotations(annotations) {
+        const parts = CFI.parse(annotations[0].value)
+        const top = (parts.parent ?? parts).shift()
+        let $itemref = CFI.toElement(this.opf, top)
+        // make sure it's an idref; if not, try again without the ID assertion
+        // mainly because Epub.js used to generate wrong ID assertions
+        // https://github.com/futurepress/epub.js/issues/1236
+        if ($itemref && $itemref.nodeName !== 'idref') {
+            top.at(-1).id = null
+            $itemref = CFI.toElement(this.opf, top)
+        }
+        const idref = $itemref?.getAttribute('idref')
+        const index = this.spine.findIndex(item => item.idref === idref)
+        const anchor = doc => CFI.toRange(doc, parts)
+        console.log(index, anchor)
+        console.log(annotations, annotations[0].value)
+        this.add_mark(CFI.collapse(annotations[0].value), Gtk.PositionType.BOTTOM, null)
+    }
     update(fraction) {
         if (this.#shouldUpdate) {
             this.#shouldGo = false
@@ -206,6 +225,9 @@ GObject.registerClass({
     }
     loadSections(sections) {
         this._progress_scale.loadSections(sections)
+    }
+    loadAnnotations(annotations) {
+        this._progress_scale.loadAnnotations(annotations)
     }
     loadPageList(pageList, total) {
         if (!pageList?.length) {


### PR DESCRIPTION
Hi johnfactotum,

I have added annotation marks at the navbar that appear at the bottom. My initial goal was to have them colorful and consistent with the chosen colors of the annotations. However, it seems that the library does not support colorful marks, so I placed them at the bottom to differentiate between section and annotation marks.

The annotations marks are not accurate and can be quite off because I get the location when I save them, instead of using the more accurate cfi (don't know how to transform it into a fraction). I also used two 100ms setTimeouts in order to wait and load the marks after an annotation was added/deleted (I think this can be improved using callbacks maybe).

Let me know what you think about this functionality, as I have other ideas I would also like to experiment with.
Thanks!