### PR TITLE
Remove unused 'new window' entry of the desktop file

### DIFF
--- a/data/com.github.johnfactotum.Foliate.desktop.in
+++ b/data/com.github.johnfactotum.Foliate.desktop.in
@@ -10,7 +10,6 @@ Terminal=false
 Type=Application
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=Ebook;Book;EPUB;Viewer;Reader;
-Actions=new-window;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
 StartupNotify=true


### PR DESCRIPTION
When you run the `meson test` it will fail with

```
----------------------------------- stdout -----------------------------------
data/com.github.johnfactotum.Foliate.desktop: error: action "new-window" is defined, but there is no matching "Desktop Action new-window" group
```

This PR removes this unused line and fixes this test.

This will also fix up the "unknown" line in the right click menu on the dash.

![grafik](https://github.com/johnfactotum/foliate/assets/18744080/2cdfbec0-34f3-44c0-8c97-e06a55c5a52d)
