### PR TITLE
Disable subpixel smoothing when the reader is going to be inverted.

### DIFF
--- a/src/web/epub-viewer.js
+++ b/src/web/epub-viewer.js
@@ -302,6 +302,7 @@ const setStyle = style => {
             'background': bgColor,
             'font-size': `${fontSize}px !important`,
             'line-height': `${spacing} !important`,
+            '-webkit-font-smoothing': invert ? 'antialiased' : 'auto',
             '-webkit-hyphens': hyphenate ? 'auto' : 'manual',
             '-webkit-hyphenate-limit-before': 3,
             '-webkit-hyphenate-limit-after': 2,


### PR DESCRIPTION
The 'Invert' theme inverting text after subpixel smoothing has already been applied was causing some pretty unpleasant-to-look-at chromatic aberration.

The `gtk4` branch does not appear to have this theme. It seems like maybe it's intended to come back, based on the styles in `reader.html`, but I'm not going to try to fix this there since I can't test it.

Before:
![dark-prod](https://github.com/johnfactotum/foliate/assets/1394710/162d90d8-4472-45d0-80bb-f8c8f8cc64d4)

In this branch:
![dark-antialiased](https://github.com/johnfactotum/foliate/assets/1394710/5ac0a694-b8e6-48db-a1f1-f0c556ae67b9)

