### PR TITLE
snap: fix unable to open files from right click

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,6 +28,8 @@ apps:
     extensions:
       - gnome
     plugs:
+      - home
+      - removable-media
       - network
       - audio-playback
     desktop: usr/share/applications/com.github.johnfactotum.Foliate.desktop


### PR DESCRIPTION
closes #1153