### PR TITLE
appdata: Add developer ID

### DIFF
--- a/data/com.github.johnfactotum.Foliate.metainfo.xml.in
+++ b/data/com.github.johnfactotum.Foliate.metainfo.xml.in
@@ -21,6 +21,9 @@
         </ul>
     </description>
     <developer_name translate="no">John Factotum</developer_name>
+    <developer id="io.github.johnfactotum">
+        <name translate="no">John Factotum</name>
+    </developer>
     <launchable type="desktop-id">com.github.johnfactotum.Foliate.desktop</launchable>
     <url type="homepage">https://johnfactotum.github.io/foliate/</url>
     <url type="vcs-browser">https://github.com/johnfactotum/foliate</url>


### PR DESCRIPTION
Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer