### PR TITLE
Remap viewer.toggle-toc to <ctrl>t

### DIFF
--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -679,7 +679,7 @@ export const BookViewer = GObject.registerClass({
             '<ctrl>f|slash': 'viewer.toggle-search',
             '<ctrl>l': 'viewer.show-location',
             '<ctrl>i|<alt>Return': 'viewer.show-info',
-            '<ctrl><alt>t': 'viewer.toggle-toc',
+            '<ctrl>t': 'viewer.toggle-toc',
             '<ctrl><alt>a': 'viewer.toggle-annotations',
             '<ctrl><alt>d': 'viewer.toggle-bookmarks',
             '<ctrl>d': 'viewer.bookmark',


### PR DESCRIPTION
`viewer.toggle-toc` is remapped to `<ctrl>t` instead of `<ctrl><alt>t`. Many people use `<ctrl><alt>t` to bring up their terminal, so it's a common conflict that can be avoided. `<ctrl>t` is also the shortcut for the same action in Calibre, so readers coming from that reader have one less new shortcut to learn.