### PR TITLE
Fix double quotes in Basque translation

### DIFF
--- a/po/eu.po
+++ b/po/eu.po
@@ -839,7 +839,7 @@ msgstr "Formatua"
 
 #: src/ui/export-dialog.ui:29
 msgid "Choose “JSON” if you plan on importing annotations back to Foliate"
-msgstr "Aukeratu "JSON" oharrak Foliate-ra berriro inportatzeko asmoa baduzu"
+msgstr "Aukeratu “JSON” oharrak Foliate-ra berriro inportatzeko asmoa baduzu"
 
 #: src/ui/export-dialog.ui:33
 msgid "JSON"


### PR DESCRIPTION
```
FAILED: data/com.github.johnfactotum.Foliate.desktop
/usr/bin/meson --internal msgfmthelper --msgfmt=/usr/bin/msgfmt
../data/com.github.johnfactotum.Foliate.desktop.in
data/com.github.johnfactotum.Foliate.desktop desktop ../data/../po
../data/../po/eu.po:842: keyword "JSON" unknown
../data/../po/eu.po:842:23: syntax error
/usr/bin/msgfmt: found 2 fatal errors
```