### PR TITLE
Add Spiel speech API

### DIFF
--- a/src/gresource.xml
+++ b/src/gresource.xml
@@ -13,6 +13,7 @@
     <file>search.js</file>
     <file>selection-tools.js</file>
     <file>speech.js</file>
+    <file>spiel.js</file>
     <file>toc.js</file>
     <file>themes.js</file>
     <file>tts.js</file>

--- a/src/spiel.js
+++ b/src/spiel.js
@@ -1,0 +1,47 @@
+import Gio from 'gi://Gio'
+import Spiel from 'gi://Spiel'
+
+Gio._promisify(Spiel.Speaker, 'new')
+
+export class SpielClient {
+    #speaker
+    #pitch = 1.0
+    #rate = 1.0
+    #promises = new Map()
+    async init() {
+        if (!this.#speaker) {
+          this.#speaker = await Spiel.Speaker.new(null);
+        }
+    }
+
+    speak(str) {
+        const text = str.replace('\r\n.', '\r\n..') + '\r\n.'
+        console.log(`speak: "${text}"`);
+        const rate = this.#rate;
+        const pitch = this.#pitch;
+        const utterance = new Spiel.Utterance({text, rate, pitch, is_ssml: true});
+        let speaker = this.#speaker;
+        return new Promise((resolve, reject) => {
+          speaker.connect('utterance-finished', (_, utt) => { if (utt == utterance) resolve(); });
+          speaker.connect('utterance-canceled', (_, utt) => { if (utt == utterance) resolve(); });
+          speaker.connect('utterance-error', (_, utt, err) => { if (utt == utterance) reject(err); });
+          speaker.speak(utterance);
+        });
+    }
+    pause() {
+        this.#speaker.pause();
+        return this.send('PAUSE self')
+    }
+    resume() {
+        this.#speaker.resume();
+    }
+    stop() {
+        this.#speaker.cancel();
+    }
+    setRate(rate) {
+        this.#rate = rate;
+    }
+    setPitch(pitch) {
+        this.#pitch = pitch;
+    }
+}

--- a/src/tts.js
+++ b/src/tts.js
@@ -3,9 +3,11 @@ import GObject from 'gi://GObject'
 import { gettext as _ } from 'gettext'
 
 import * as utils from './utils.js'
-import { SSIPClient } from './speech.js'
+// import { SSIPClient } from './speech.js'
+import { SpielClient } from './spiel.js'
 
-const ssip = new SSIPClient()
+// const ssip = new SSIPClient()
+const ssip = new SpielClient()
 
 GObject.registerClass({
     GTypeName: 'FoliateTTSBox',
@@ -61,7 +63,7 @@ GObject.registerClass({
             : 'media-playback-start-symbolic'
     }
     #init() {
-        return ssip.stop().then(() => this.emit('init'))
+        return ssip.init().then(() => this.emit('init'))
     }
     async #speak(ssml) {
         this.state = 'playing'


### PR DESCRIPTION
[Spiel](https://project-spiel.org/) is a modern speech synthesis API for the desktop that will hopefully support many kinds of providers and voices. It has GI bindings, so adding it to foliate shouldn't be hard.

I started a port, but ran into some trouble with how foliate creates SSML mark elements to report speech progress. Spiel has speech boundary events, including SSML marks, but now all providers support it. Unfortunately I think changes will be needed in foliate-js as well to make this work. Specifically, pre-segmenting the text into marks gets in the way here.
