### PR TITLE
Hide an inspector button from the navbar

### DIFF
--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -103,10 +103,12 @@
       <attribute name="label" translatable="yes">Print…</attribute>
       <attribute name="action">view.print</attribute>
     </item>
+    <!--
     <item>
       <attribute name="label" translatable="yes">Inspector</attribute>
       <attribute name="action">view.inspector</attribute>
     </item>
+    -->
   </section>
 </menu>
 


### PR DESCRIPTION
Why do we need to reveal an inspector button for regular users?
![image](https://github.com/user-attachments/assets/1c700f17-9d09-470b-a402-7f6d8566dd74)

And an stupid question, what the earth this "Web inspector" thing even do in the Foliate? I'm just curious :)