### PR TITLE
snap: move architectures to platforms

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,10 +5,10 @@ license: GPL-3.0+
 base: core24
 confinement: strict
 compression: lzo
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
+platforms:
+  amd64:
+  arm64:
+  armhf:
 layout:
   /usr/lib/$CRAFT_ARCH_TRIPLET/webkitgtk-6.0:
     bind: $SNAP/webkitgtk-platform/usr/lib/$CRAFT_ARCH_TRIPLET/webkitgtk-6.0


### PR DESCRIPTION
This is also needed for the core24 migration, which was causing the build failure.

https://snapcraft.io/docs/migrate-core24#p-136049-platforms