### PR TITLE
app: Idle-inhibit when window is fullscreen

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,7 @@ const ApplicationWindow = GObject.registerClass({
     #library
     #bookViewer
     #stack = new Gtk.Stack()
+    #cookie
     constructor(params) {
         super(params)
         Object.assign(this, {
@@ -79,6 +80,19 @@ const ApplicationWindow = GObject.registerClass({
 
         utils.bindSettings('window', this,
             ['default-width', 'default-height', 'maximized', 'fullscreened'])
+
+
+        this.connect('notify::fullscreened', (win) => {
+            let app = Gio.Application.get_default()
+            if (this.is_fullscreen()) {
+                this.#cookie = app.inhibit(win, Gtk.ApplicationInhibitFlags.IDLE,
+                    'Reading book in fullscreen')
+                if (this.#cookie == 0)
+                    console.error('Failed to inhibit session idle')
+            } else if (this.#cookie > 0) {
+                app.uninhibit(this.#cookie)
+            }
+        })
 
         if (this.file) this.openFile(this.file)
         else this.showLibrary()


### PR DESCRIPTION
When reading in fullscreen one usually doesn't want the session to go idle (thus dim the screen and eventually blank it).

With this reading on mobile is a breeze, without it I'd have to remember to turn on/off "caffeine" mode.

Edit: I'm not much of JS person so please excuse if this doesn't look very JS-like.