### PR TITLE
feat: Add Windows build support

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,53 @@
+name: Windows
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Set up MSYS2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        install: >-
+          mingw-w64-ucrt-x86_64-toolchain
+          mingw-w64-ucrt-x86_64-gjs
+          mingw-w64-ucrt-x86_64-gtk4
+          mingw-w64-ucrt-x86_64-libadwaita
+          mingw-w64-ucrt-x86_64-webkitgtk-6.0
+          mingw-w64-ucrt-x86_64-meson
+          mingw-w64-ucrt-x86_64-ninja
+          mingw-w64-ucrt-x86_64-pkg-config
+          mingw-w64-ucrt-x86_64-gettext
+          mingw-w64-ucrt-x86_64-glib2-devel
+
+    - name: Build
+      shell: msys2 {0}
+      run: |
+        meson setup build --prefix="$PWD/install"
+        ninja -C build install
+
+    - name: Package
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Path "install/share/icons/hicolor/scalable/apps"
+        Copy-Item "data/com.github.johnfactotum.Foliate.svg" -Destination "install/share/icons/hicolor/scalable/apps"
+        New-Item -ItemType Directory -Path "artifact"
+        Compress-Archive -Path "install/*" -DestinationPath "artifact/foliate.zip"
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: foliate-windows
+        path: artifact/foliate.zip

--- a/README.md
+++ b/README.md
@@ -106,6 +106,45 @@ Foliate is available on the [Snap Store](https://snapcraft.io/foliate). To insta
 sudo snap install foliate
 ```
 
+### Building on Windows
+
+It's possible to build this application on Windows using MSYS2.
+
+1.  **Install MSYS2**. Download and install MSYS2 from [msys2.org](https://www.msys2.org/). Follow the installation instructions.
+
+2.  **Install dependencies**. Open the MSYS2 UCRT64 shell and install the necessary dependencies:
+    ```sh
+    pacman -S --needed \
+      mingw-w64-ucrt-x86_64-toolchain \
+      mingw-w64-ucrt-x86_64-gjs \
+      mingw-w64-ucrt-x86_64-gtk4 \
+      mingw-w64-ucrt-x86_64-libadwaita \
+      mingw-w64-ucrt-x86_64-webkitgtk-6.0 \
+      mingw-w64-ucrt-x86_64-meson \
+      mingw-w64-ucrt-x86_64-ninja \
+      mingw-w64-ucrt-x86_64-pkg-config \
+      mingw-w64-ucrt-x86_64-gettext \
+      mingw-w64-ucrt-x86_64-glib2-devel
+    ```
+
+3.  **Clone the repository**.
+    ```sh
+    git clone --recurse-submodules https://github.com/johnfactotum/foliate.git
+    cd foliate
+    ```
+
+4.  **Build and install**.
+    ```sh
+    meson setup build --prefix="$PWD/install"
+    ninja -C build install
+    ```
+
+5.  **Run**.
+    After the build is complete, you can run the application from the `install` directory. You will need to set the `GSETTINGS_SCHEMA_DIR` environment variable.
+    ```sh
+    GSETTINGS_SCHEMA_DIR=$PWD/install/share/glib-2.0/schemas ./install/bin/foliate
+    ```
+
 ## Screenshots
 
 ![Dark mode](data/screenshots/dark.png)


### PR DESCRIPTION
This commit introduces the necessary infrastructure to build the application on Windows using MSYS2.

- A new GitHub Actions workflow (`windows.yml`) is added to automate the build, packaging, and artifact upload for Windows.
- The README.md is updated with detailed instructions for developers on how to set up a local Windows build environment with MSYS2, install dependencies, and compile the application.