### PR TITLE
Add "Books" to list of keywords in .desktop file

### DIFF
--- a/data/com.github.johnfactotum.Foliate.desktop.in
+++ b/data/com.github.johnfactotum.Foliate.desktop.in
@@ -10,7 +10,7 @@ Icon=com.github.johnfactotum.Foliate
 Terminal=false
 Type=Application
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
-Keywords=Ebook;Book;EPUB;Viewer;Reader;
+Keywords=Ebook;Book;Books;EPUB;Viewer;Reader;
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;
 StartupNotify=true


### PR DESCRIPTION
Perhaps changing the "book" keyword that exists would be the better move. I don't mind either way, I just want to be able to type "books" into a system search and get books.