### PR TITLE
fix crash and improve fractions in list view of library

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -279,7 +279,7 @@ const BookRow = GObject.registerClass({
     update(item, data) {
         this.#item = item
         const { metadata, progress } = data
-        const title = metadata?.title
+        const title = formatLanguageMap(metadata?.title)
         this._title.label = title
 
         const author = formatAuthors(metadata)

--- a/src/library.js
+++ b/src/library.js
@@ -219,7 +219,7 @@ GObject.registerClass({
     }
 })
 
-const fraction = p => p?.[1] ? (p[0] + 1) / (p[1] + 1) : null
+const fraction = p => !isNaN(p?.[1]) && p?.[1] > 0 ? p[0] / p[1] : null
 
 const BookItem = GObject.registerClass({
     GTypeName: 'FoliateBookItem',


### PR DESCRIPTION
## correctly parse title in list view regardless of type
    
The title can be an object, a string or null. Setting a
label to null instead of "" is an uncatchable exception.
Thus, if this even happens, Foliate will crash.

## improve fraction calculation
    
With a zero-based index, this assumes if you are on a
page, that you read it partially exactly to the amount
of pages you read before relative to the amount of pages
before and after. That results in the first page being
considered unread and the last page being fully read of
you were on those pages.

While this is not accurate, there is no way to accurately
determine the current sub-page percentage a person read.
However, at least, this results in the percentage going
from 0 % to 100 % for any given book. Thus, opening a
book for the first time and not starting to read it marks
it as 0 %, which is the desired outcome of this change.