### PR TITLE
feat: ✨ Added the keyboard shortcuts help page

### DIFF
--- a/com.github.johnfactotum.Foliate.json
+++ b/com.github.johnfactotum.Foliate.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.johnfactotum.Foliate",
     "runtime" : "org.gnome.Sdk",
-    "runtime-version" : "48",
+    "runtime-version" : "49",
     "sdk" : "org.gnome.Sdk",
     "command" : "foliate",
     "finish-args" : [

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -18,6 +18,7 @@ src/ui/book-row.ui
 src/ui/book-viewer.ui
 src/ui/bookmark-row.ui
 src/ui/export-dialog.ui
+src/ui/help-overlay.ui
 src/ui/image-viewer.ui
 src/ui/import-dialog.ui
 src/ui/library.ui

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -680,7 +680,7 @@ export const BookViewer = GObject.registerClass({
             actions: [
                 'toggle-sidebar', 'toggle-search', 'show-location',
                 'toggle-toc', 'toggle-annotations', 'toggle-bookmarks',
-                'preferences', 'show-info', 'bookmark',
+                'preferences', 'help-overlay', 'show-info', 'bookmark',
                 'export-annotations', 'import-annotations',
             ],
             props: ['fold-sidebar'],
@@ -698,13 +698,14 @@ export const BookViewer = GObject.registerClass({
             '<ctrl><alt>d': 'viewer.toggle-bookmarks',
             '<ctrl>d': 'viewer.bookmark',
             '<alt>comma': 'viewer.preferences',
+            '<ctrl>question': 'viewer.help-overlay',
             '<ctrl><shift>g': 'search.prev',
             '<ctrl>g': 'search.next',
             '<ctrl>c': 'selection.copy',
             '<ctrl>f': 'selection.search',
             'F12': 'view.inspector',
             '<ctrl>m': 'view.scrolled',
-            '<ctrl>r': 'view.reload',
+            '<ctrl>r|F5': 'view.reload',
             'plus|equal|KP_Add|KP_Equal|<ctrl>plus|<ctrl>equal|<ctrl>KP_Add|<ctrl>KP_Equal': 'view.zoom-in',
             'minus|KP_Subtract|<ctrl>minus|<ctrl>KP_Subtract': 'view.zoom-out',
             '0|1|KP_0|<ctrl>0|<ctrl>KP_0': 'view.zoom-restore',
@@ -1002,6 +1003,14 @@ export const BookViewer = GObject.registerClass({
     }
     importAnnotations() {
         importAnnotations(this.root, this.#data)
+    }
+    helpOverlay() {
+        const path = pkg.modulepath('ui/help-overlay.ui')
+        const builder = pkg.useResource
+            ? Gtk.Builder.new_from_resource(path)
+            : Gtk.Builder.new_from_file(path)
+        const dialog = builder.get_object('help-overlay')
+        dialog.present(this.root)
     }
     vfunc_unroot() {
         this._navbar.tts_box.kill()

--- a/src/gresource.xml
+++ b/src/gresource.xml
@@ -26,6 +26,7 @@
     <file>ui/book-viewer.ui</file>
     <file>ui/bookmark-row.ui</file>
     <file>ui/export-dialog.ui</file>
+    <file>ui/help-overlay.ui</file>
     <file>ui/image-viewer.ui</file>
     <file>ui/import-dialog.ui</file>
     <file>ui/library-view.ui</file>

--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -27,12 +27,10 @@
     </item>
   </section>
   <section>
-    <!--
     <item>
       <attribute name="label" translatable="yes">Keyboard Shortcuts</attribute>
-      <attribute name="action">win.help-overlay</attribute>
+      <attribute name="action">viewer.help-overlay</attribute>
     </item>
-    -->
     <item>
       <attribute name="label" translatable="yes">About Foliate</attribute>
       <attribute name="action">app.about</attribute>

--- a/src/ui/help-overlay.ui
+++ b/src/ui/help-overlay.ui
@@ -1,0 +1,256 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<interface>
+  <object class="AdwShortcutsDialog" id="help-overlay">
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-navigation">
+        <property name="title" translatable="yes">Navigation</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">p Page_Up &lt;shift&gt;space</property>
+            <property name="title" translatable="yes">Previous Page</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">n Page_Down space</property>
+            <property name="title" translatable="yes">Next Page</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">h Left</property>
+            <property name="title" translatable="yes">Go Left</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">j Down</property>
+            <property name="title" translatable="yes">Scroll Down</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">k Up</property>
+            <property name="title" translatable="yes">Scroll Up</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">l Right</property>
+            <property name="title" translatable="yes">Go Right</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;alt&gt;Left</property>
+            <property name="title" translatable="yes">Jump to Previous Location</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;alt&gt;Right</property>
+            <property name="title" translatable="yes">Jump to Next Location</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-sidebar">
+        <property name="title" translatable="yes">Sidebar</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">F9</property>
+            <property name="title" translatable="yes">Toggle Sidebar</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;t</property>
+            <property name="title" translatable="yes">Toggle Table of Contents</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;&lt;alt&gt;a</property>
+            <property name="title" translatable="yes">Toggle Annotations</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;&lt;alt&gt;d</property>
+            <property name="title" translatable="yes">Toggle Bookmarks</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">slash &lt;ctrl&gt;f</property>
+            <property name="title" translatable="yes">Toggle Search</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-view">
+        <property name="title" translatable="yes">View</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">F5 &lt;ctrl&gt;r</property>
+            <property name="title" translatable="yes">Reload</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">plus &lt;ctrl&gt;plus</property>
+            <property name="title" translatable="yes">Zoom In</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">minus &lt;ctrl&gt;minus</property>
+            <property name="title" translatable="yes">Zoom Out</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">0 &lt;ctrl&gt;0</property>
+            <property name="title" translatable="yes">Reset Zoom</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">F11</property>
+            <property name="title" translatable="yes">Toggle Fullscreen</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;m</property>
+            <property name="title" translatable="yes">Toggle Scrolled Mode</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;l</property>
+            <property name="title" translatable="yes">Show Current Location</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;d</property>
+            <property name="title" translatable="yes">Bookmark Current Location</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-in-search">
+        <property name="title" translatable="yes">In Search</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;&lt;shift&gt;g</property>
+            <property name="title" translatable="yes">Previous</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;g</property>
+            <property name="title" translatable="yes">Next</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-in-selection">
+        <property name="title" translatable="yes">With Selection</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;c</property>
+            <property name="title" translatable="yes">Selection Copy</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;f</property>
+            <property name="title" translatable="yes">Selection Search</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-window">
+        <property name="title" translatable="yes">Window</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;o</property>
+            <property name="title" translatable="yes">Open File</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;n</property>
+            <property name="title" translatable="yes">Open a Copy</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;w</property>
+            <property name="title" translatable="yes">Close Window</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;q</property>
+            <property name="title" translatable="yes">Quit</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="AdwShortcutsSection" id="shortcuts-general">
+        <property name="title" translatable="yes">General</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;i &lt;alt&gt;Return</property>
+            <property name="title" translatable="yes">Show Book Information</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">F1</property>
+            <property name="title" translatable="yes">Show App Information</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">F10</property>
+            <property name="title" translatable="yes">Open Menu</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;alt&gt;comma</property>
+            <property name="title" translatable="yes">Font &amp; Layout Settings</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;question</property>
+            <property name="title" translatable="yes">Keyboard Shortcuts</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">&lt;ctrl&gt;p</property>
+            <property name="title" translatable="yes">Print...</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="accelerator">F12</property>
+            <property name="title" translatable="yes">Inspector</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>


### PR DESCRIPTION
Added a GTK4 keyboard shortcuts window in the book menu and tied it to `<ctrl>?`. Addresses issue #1310 and discussion #1233.

Note that while `GtkShortcutsWindow` and its children are marked as deprecated, the documentation also states that there isn't an alternative yet, and that an eventual new implementation will be for Gtk5.