### PR TITLE
Inhibit Idle when window is maximized

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -83,12 +83,17 @@ const ApplicationWindow = GObject.registerClass({
 
 
         const app = Gio.Application.get_default()
-        const inhibitIdle = (win) => {
+        const toggleInhibitIdle = (win) => {
+            const canInhibit = this.is_active && (this.is_fullscreen() || this.is_maximized())
+            if (!canInhibit) {
+                uninhibitIdle()
+                return
+            }
             if (this.#inhibitCookie) return
             const inhibitCookie = app.inhibit(
                 win,
                 Gtk.ApplicationInhibitFlags.IDLE,
-                'Reading book in fullscreen or a maximized window',
+                'Reading a book in an active fullscreen or maximized window',
             )
             if (inhibitCookie === 0) console.error('Failed to inhibit session idle')
             else this.#inhibitCookie = inhibitCookie
@@ -99,12 +104,13 @@ const ApplicationWindow = GObject.registerClass({
             this.#inhibitCookie = null
         }
         this.connect('notify::fullscreened', (win) => {
-            if (this.is_fullscreen() || this.is_maximized()) inhibitIdle(win)
-            else uninhibitIdle()
+            toggleInhibitIdle(win)
         })
         this.connect('notify::maximized', (win) => {
-            if (this.is_fullscreen() || this.is_maximized()) inhibitIdle(win)
-            else uninhibitIdle()
+            toggleInhibitIdle()
+        })
+        this.connect('notify::is-active', (win) => {
+            toggleInhibitIdle(win)
         })
 
         if (this.file) this.openFile(this.file)

--- a/src/app.js
+++ b/src/app.js
@@ -54,7 +54,7 @@ const ApplicationWindow = GObject.registerClass({
     #library
     #bookViewer
     #stack = new Gtk.Stack()
-    #cookie
+    #inhibitCookie = null
     constructor(params) {
         super(params)
         Object.assign(this, {
@@ -82,16 +82,29 @@ const ApplicationWindow = GObject.registerClass({
             ['default-width', 'default-height', 'maximized', 'fullscreened'])
 
 
+        const app = Gio.Application.get_default()
+        const inhibitIdle = (win) => {
+            if (this.#inhibitCookie) return
+            const inhibitCookie = app.inhibit(
+                win,
+                Gtk.ApplicationInhibitFlags.IDLE,
+                'Reading book in fullscreen or a maximized window',
+            )
+            if (inhibitCookie === 0) console.error('Failed to inhibit session idle')
+            else this.#inhibitCookie = inhibitCookie
+        }
+        const uninhibitIdle = () => {
+            if (!this.#inhibitCookie) return
+            app.uninhibit(this.#inhibitCookie)
+            this.#inhibitCookie = null
+        }
         this.connect('notify::fullscreened', (win) => {
-            let app = Gio.Application.get_default()
-            if (this.is_fullscreen()) {
-                this.#cookie = app.inhibit(win, Gtk.ApplicationInhibitFlags.IDLE,
-                    'Reading book in fullscreen')
-                if (this.#cookie == 0)
-                    console.error('Failed to inhibit session idle')
-            } else if (this.#cookie > 0) {
-                app.uninhibit(this.#cookie)
-            }
+            if (this.is_fullscreen() || this.is_maximized()) inhibitIdle(win)
+            else uninhibitIdle()
+        })
+        this.connect('notify::maximized', (win) => {
+            if (this.is_fullscreen() || this.is_maximized()) inhibitIdle(win)
+            else uninhibitIdle()
         })
 
         if (this.file) this.openFile(this.file)


### PR DESCRIPTION
Currently, the application inhibits idle only for full-screen mode.
It would be helpful to have this when the window is maximized as well.

Closes #1609 