### PR TITLE
Import multiple books

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -74,7 +74,7 @@ const ApplicationWindow = GObject.registerClass({
         this.connect('destroy', () => styleManager.disconnect(handler))
 
         utils.addMethods(this, {
-            actions: ['open', 'close', 'show-library', 'show-menu', 'new-window', 'open-copy'],
+            actions: ['open', 'close', 'show-library', 'show-menu', 'new-window', 'open-copy', 'import-books'],
             props: ['fullscreened'],
         })
 
@@ -173,6 +173,202 @@ const ApplicationWindow = GObject.registerClass({
             }
         })
     }
+    #collectEbooksFromDirectory(directory, files = []) {
+        const ebookExtensions = ['.epub', '.mobi', '.azw', '.azw3', '.fb2', '.fb2.zip', '.cbz']
+        try {
+            const enumerator = directory.enumerate_children(
+                'standard::name,standard::type',
+                Gio.FileQueryInfoFlags.NONE,
+                null,
+            )
+            let info
+            while ((info = enumerator.next_file(null))) {
+                const name = info.get_name()
+                
+                // Skip hidden files and macOS resource forks
+                if (name.startsWith('.')) continue
+                
+                const child = directory.get_child(name)
+                const fileType = info.get_file_type()
+
+                if (fileType === Gio.FileType.DIRECTORY) {
+                    this.#collectEbooksFromDirectory(child, files)
+                } else if (fileType === Gio.FileType.REGULAR) {
+                    const nameLower = name.toLowerCase()
+                    if (ebookExtensions.some(ext => nameLower.endsWith(ext))) {
+                        files.push(child)
+                    }
+                }
+            }
+            enumerator.close(null)
+        } catch (e) {
+            console.warn(`Failed to read directory ${directory.get_path()}: ${e}`)
+        }
+        return files
+    }
+    #importMultipleFiles() {
+        const dialog = new Gtk.FileDialog()
+        const ebooks = new Gtk.FileFilter({
+            name: _('E-Book Files'),
+            mime_types: [
+                'application/epub+zip',
+                'application/x-mobipocket-ebook',
+                'application/vnd.amazon.mobi8-ebook',
+                'application/x-mobi8-ebook',
+                'application/x-fictionbook+xml',
+                'application/x-zip-compressed-fb2',
+                'application/vnd.comicbook+zip',
+            ],
+        })
+        dialog.filters = new Gio.ListStore()
+        dialog.filters.append(new Gtk.FileFilter({
+            name: _('All Files'),
+            patterns: ['*'],
+        }))
+        dialog.filters.append(ebooks)
+        dialog.default_filter = ebooks
+
+        dialog.open_multiple(this, null, (_, res) => {
+            try {
+                const files = dialog.open_multiple_finish(res)
+                let importedCount = 0
+                for (let i = 0; i < files.get_n_items(); i++) {
+                    const file = files.get_item(i)
+                    this.openFile(file)
+                    importedCount++
+                }
+                if (importedCount > 0) {
+                    this.showLibrary()
+                    const toast = new Adw.Toast({
+                        title: importedCount === 1
+                            ? _('Imported 1 book')
+                            : _(`Imported ${importedCount} books`),
+                    })
+                    this.add_toast(toast)
+                }
+            } catch (e) {
+                if (e instanceof Gtk.DialogError) console.debug(e)
+                else console.error(e)
+            }
+        })
+    }
+    #importFromFolder() {
+        const dialog = new Gtk.FileDialog()
+        dialog.select_folder(this, null, async (obj, res) => {
+            try {
+                const folder = dialog.select_folder_finish(res)
+                const files = this.#collectEbooksFromDirectory(folder)
+                let importedCount = 0
+                
+                // Process books one by one
+                for (const file of files) {
+                    try {
+                        await this.#processBookForImport(file)
+                        importedCount++
+                        // Delay to allow cleanup and trigger GC between books
+                        await new Promise(resolve => 
+                            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
+                                // Suggest GC to clean up before next book
+                                imports.system.gc()
+                                resolve()
+                                return GLib.SOURCE_REMOVE
+                            })
+                        )
+                    } catch (e) {
+                        console.error(`Failed to import ${file.get_path()}:`, e)
+                    }
+                }
+                
+                if (importedCount > 0) {
+                    this.showLibrary()
+                    const toast = new Adw.Toast({
+                        title: importedCount === 1
+                            ? _('Imported 1 book from folder')
+                            : _(`Imported ${importedCount} books from folder`),
+                    })
+                    this.add_toast(toast)
+                } else {
+                    const toast = new Adw.Toast({
+                        title: _('No e-books found in the selected folder'),
+                    })
+                    this.add_toast(toast)
+                }
+            } catch (e) {
+                if (e instanceof Gtk.DialogError) console.debug(e)
+                else console.error(e)
+            }
+        })
+    }
+    #processBookForImport(file) {
+        return new Promise((resolve, reject) => {
+            // Use the existing BookViewer but keep strong references
+            if (!this.#bookViewer) {
+                this.#bookViewer = new BookViewer()
+                this.#stack.add_child(this.#bookViewer)
+            }
+            
+            // Keep reference to prevent GC
+            const viewer = this.#bookViewer
+            const view = viewer._view
+            let completed = false
+            const handlers = []
+            
+            const cleanup = (success, error) => {
+                if (completed) return
+                completed = true
+                
+                // Disconnect all handlers
+                handlers.forEach(id => {
+                    try {
+                        view.disconnect(id)
+                    } catch (e) {
+                        // Ignore disconnect errors
+                    }
+                })
+                handlers.length = 0
+                
+                // Schedule resolution after current event loop to avoid GC issues
+                GLib.idle_add(GLib.PRIORITY_LOW, () => {
+                    if (success) resolve()
+                    else if (error) reject(error)
+                    return GLib.SOURCE_REMOVE
+                })
+            }
+            
+            // Use handler array to track connections
+            handlers.push(view.connect('book-ready', () => cleanup(true, null)))
+            handlers.push(view.connect('book-error', () => cleanup(false, new Error('Failed to load book'))))
+            
+            // Timeout
+            GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 30, () => {
+                cleanup(false, new Error('Book loading timed out'))
+                return GLib.SOURCE_REMOVE
+            })
+            
+            // Open the book
+            viewer.open(file)
+        })
+    }
+    importBooks() {
+        const dialog = new Adw.AlertDialog({
+            heading: _('Import Books'),
+            body: _('Choose how you want to import books to your library'),
+        })
+        dialog.add_response('cancel', _('Cancel'))
+        dialog.add_response('files', _('Select Files'))
+        dialog.add_response('folder', _('Select Folder'))
+        dialog.set_response_appearance('files', Adw.ResponseAppearance.SUGGESTED)
+        dialog.choose(this, null, (_, res) => {
+            try {
+                const response = dialog.choose_finish(res)
+                if (response === 'files') this.#importMultipleFiles()
+                else if (response === 'folder') this.#importFromFolder()
+            } catch (e) {
+                if (e instanceof Gtk.DialogError) console.debug(e)
+                else console.error(e)
+            }
+        })
+    }
     showLibrary() {
         this.file = null
         this.title = pkg.localeName
@@ -225,6 +421,7 @@ export const Application = GObject.registerClass({
             'win.show-menu': ['F10'],
             'win.open': ['<ctrl>o'],
             'win.open-copy': ['<ctrl>n'],
+            'win.import-books': ['<ctrl><shift>o'],
         })) this.set_accels_for_action(key, val)
     }
     connectStartup() {

--- a/src/app.js
+++ b/src/app.js
@@ -54,11 +54,32 @@ const EBOOK_MIME_TYPES = [
     'application/x-fictionbook+xml',
     'application/x-zip-compressed-fb2',
     'application/vnd.comicbook+zip',
+    'application/vnd.comicbook-rar',
+    'application/x-cbr',
+    'application/x-cbz',
+    'application/x-cb7',
+    'application/x-cbt',
 ]
 
 const isEbookFile = (file) => {
-    const [, contentType] = Gio.content_type_guess(file.get_path(), null)
-    return EBOOK_MIME_TYPES.includes(contentType)
+    try {
+        const path = file.get_path()
+        if (!path) {
+            console.debug('File has no path, cannot determine type')
+            return false
+        }
+        
+        // Try MIME type detection first
+        const [mimeType, _certain] = Gio.content_type_guess(path, null)
+        if (mimeType && EBOOK_MIME_TYPES.includes(mimeType)) {
+            return true
+        }
+        
+        return false
+    } catch (e) {
+        console.warn(`Failed to check if file is an ebook (${file.get_uri()}): ${e}`)
+        return false
+    }
 }
 
 const ApplicationWindow = GObject.registerClass({
@@ -213,6 +234,70 @@ const ApplicationWindow = GObject.registerClass({
         }
         return files
     }
+    #importFilesInBackground(files) {
+        // Import files by adding them to the library without rendering
+        // Just store the file URIs - metadata will be extracted when books are first opened
+        let toast = new Adw.Toast({
+            title: files.length === 1
+                ? _('Importing 1 book…')
+                : _(`Importing ${files.length} books…`),
+            timeout: 0,
+        })
+        this.add_toast(toast)
+        
+        // Show library view immediately
+        this.showLibrary()
+        
+        // Import each file by just opening it once to trigger metadata extraction
+        // but do it in the hidden bookviewer to avoid visual flashing
+        let currentIndex = 0
+        let hiddenViewer = null
+        
+        const importNext = () => {
+            if (currentIndex >= files.length) {
+                // Clean up
+                if (hiddenViewer) {
+                    this.#stack.remove(hiddenViewer)
+                    hiddenViewer = null
+                }
+                toast.dismiss()
+                
+                const finalToast = new Adw.Toast({
+                    title: files.length === 1
+                        ? _('Imported 1 book')
+                        : _(`Imported ${files.length} books`),
+                })
+                this.add_toast(finalToast)
+                return
+            }
+            
+            const file = files[currentIndex]
+            currentIndex++
+            
+            // Update toast with current progress
+            if (files.length > 1) {
+                toast.title = _(`Importing ${currentIndex} of ${files.length} books…`)
+            }
+            
+            // Create hidden viewer if needed
+            if (!hiddenViewer) {
+                hiddenViewer = new BookViewer()
+                this.#stack.add_child(hiddenViewer)
+                // Keep library visible
+            }
+            
+            // Open file in hidden viewer to extract metadata
+            hiddenViewer.open(file)
+            
+            // Continue with next file after a delay
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
+                importNext()
+                return GLib.SOURCE_REMOVE
+            })
+        }
+        
+        importNext()
+    }
     #importMultipleFiles() {
         const dialog = new Gtk.FileDialog()
         const ebooks = new Gtk.FileFilter({
@@ -229,22 +314,13 @@ const ApplicationWindow = GObject.registerClass({
 
         dialog.open_multiple(this, null, (_, res) => {
             try {
-                const files = dialog.open_multiple_finish(res)
-                let importedCount = 0
-                for (let i = 0; i < files.get_n_items(); i++) {
-                    const file = files.get_item(i)
-                    // Just open the file - this adds it to the library
-                    this.openFile(file)
-                    importedCount++
+                const gfiles = dialog.open_multiple_finish(res)
+                const files = []
+                for (let i = 0; i < gfiles.get_n_items(); i++) {
+                    files.push(gfiles.get_item(i))
                 }
-                if (importedCount > 0) {
-                    this.showLibrary()
-                    const toast = new Adw.Toast({
-                        title: importedCount === 1
-                            ? _('Imported 1 book')
-                            : _(`Imported ${importedCount} books`),
-                    })
-                    this.add_toast(toast)
+                if (files.length > 0) {
+                    this.#importFilesInBackground(files)
                 }
             } catch (e) {
                 if (e instanceof Gtk.DialogError) console.debug(e)
@@ -260,16 +336,7 @@ const ApplicationWindow = GObject.registerClass({
                 const files = this.#collectEbooksFromDirectory(folder)
                 
                 if (files.length > 0) {
-                    // Open each file - this adds them to the library
-                    files.forEach(file => this.openFile(file))
-                    
-                    this.showLibrary()
-                    const toast = new Adw.Toast({
-                        title: files.length === 1
-                            ? _('Imported 1 book from folder')
-                            : _(`Imported ${files.length} books from folder`),
-                    })
-                    this.add_toast(toast)
+                    this.#importFilesInBackground(files)
                 } else {
                     const toast = new Adw.Toast({
                         title: _('No e-books found in the selected folder'),

--- a/src/app.js
+++ b/src/app.js
@@ -45,6 +45,22 @@ User directories:
     }
 }
 
+// Shared constants for ebook file types
+const EBOOK_MIME_TYPES = [
+    'application/epub+zip',
+    'application/x-mobipocket-ebook',
+    'application/vnd.amazon.mobi8-ebook',
+    'application/x-mobi8-ebook',
+    'application/x-fictionbook+xml',
+    'application/x-zip-compressed-fb2',
+    'application/vnd.comicbook+zip',
+]
+
+const isEbookFile = (file) => {
+    const [, contentType] = Gio.content_type_guess(file.get_path(), null)
+    return EBOOK_MIME_TYPES.includes(contentType)
+}
+
 const ApplicationWindow = GObject.registerClass({
     GTypeName: 'FoliateApplicationWindow',
     Properties: utils.makeParams({
@@ -146,15 +162,7 @@ const ApplicationWindow = GObject.registerClass({
         const dialog = new Gtk.FileDialog()
         const ebooks = new Gtk.FileFilter({
             name: _('E-Book Files'),
-            mime_types: [
-                'application/epub+zip',
-                'application/x-mobipocket-ebook',
-                'application/vnd.amazon.mobi8-ebook',
-                'application/x-mobi8-ebook',
-                'application/x-fictionbook+xml',
-                'application/x-zip-compressed-fb2',
-                'application/vnd.comicbook+zip',
-            ],
+            mime_types: EBOOK_MIME_TYPES,
         })
         dialog.filters = new Gio.ListStore()
         dialog.filters.append(new Gtk.FileFilter({
@@ -174,7 +182,6 @@ const ApplicationWindow = GObject.registerClass({
         })
     }
     #collectEbooksFromDirectory(directory, files = []) {
-        const ebookExtensions = ['.epub', '.mobi', '.azw', '.azw3', '.fb2', '.fb2.zip', '.cbz']
         try {
             const enumerator = directory.enumerate_children(
                 'standard::name,standard::type',
@@ -194,8 +201,8 @@ const ApplicationWindow = GObject.registerClass({
                 if (fileType === Gio.FileType.DIRECTORY) {
                     this.#collectEbooksFromDirectory(child, files)
                 } else if (fileType === Gio.FileType.REGULAR) {
-                    const nameLower = name.toLowerCase()
-                    if (ebookExtensions.some(ext => nameLower.endsWith(ext))) {
+                    // Use content_type_guess instead of file extensions
+                    if (isEbookFile(child)) {
                         files.push(child)
                     }
                 }
@@ -210,15 +217,7 @@ const ApplicationWindow = GObject.registerClass({
         const dialog = new Gtk.FileDialog()
         const ebooks = new Gtk.FileFilter({
             name: _('E-Book Files'),
-            mime_types: [
-                'application/epub+zip',
-                'application/x-mobipocket-ebook',
-                'application/vnd.amazon.mobi8-ebook',
-                'application/x-mobi8-ebook',
-                'application/x-fictionbook+xml',
-                'application/x-zip-compressed-fb2',
-                'application/vnd.comicbook+zip',
-            ],
+            mime_types: EBOOK_MIME_TYPES,
         })
         dialog.filters = new Gio.ListStore()
         dialog.filters.append(new Gtk.FileFilter({
@@ -234,6 +233,7 @@ const ApplicationWindow = GObject.registerClass({
                 let importedCount = 0
                 for (let i = 0; i < files.get_n_items(); i++) {
                     const file = files.get_item(i)
+                    // Just open the file - this adds it to the library
                     this.openFile(file)
                     importedCount++
                 }
@@ -254,37 +254,20 @@ const ApplicationWindow = GObject.registerClass({
     }
     #importFromFolder() {
         const dialog = new Gtk.FileDialog()
-        dialog.select_folder(this, null, async (obj, res) => {
+        dialog.select_folder(this, null, (obj, res) => {
             try {
                 const folder = dialog.select_folder_finish(res)
                 const files = this.#collectEbooksFromDirectory(folder)
-                let importedCount = 0
                 
-                // Process books one by one
-                for (const file of files) {
-                    try {
-                        await this.#processBookForImport(file)
-                        importedCount++
-                        // Delay to allow cleanup and trigger GC between books
-                        await new Promise(resolve => 
-                            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 500, () => {
-                                // Suggest GC to clean up before next book
-                                imports.system.gc()
-                                resolve()
-                                return GLib.SOURCE_REMOVE
-                            })
-                        )
-                    } catch (e) {
-                        console.error(`Failed to import ${file.get_path()}:`, e)
-                    }
-                }
-                
-                if (importedCount > 0) {
+                if (files.length > 0) {
+                    // Open each file - this adds them to the library
+                    files.forEach(file => this.openFile(file))
+                    
                     this.showLibrary()
                     const toast = new Adw.Toast({
-                        title: importedCount === 1
+                        title: files.length === 1
                             ? _('Imported 1 book from folder')
-                            : _(`Imported ${importedCount} books from folder`),
+                            : _(`Imported ${files.length} books from folder`),
                     })
                     this.add_toast(toast)
                 } else {
@@ -297,56 +280,6 @@ const ApplicationWindow = GObject.registerClass({
                 if (e instanceof Gtk.DialogError) console.debug(e)
                 else console.error(e)
             }
-        })
-    }
-    #processBookForImport(file) {
-        return new Promise((resolve, reject) => {
-            // Use the existing BookViewer but keep strong references
-            if (!this.#bookViewer) {
-                this.#bookViewer = new BookViewer()
-                this.#stack.add_child(this.#bookViewer)
-            }
-            
-            // Keep reference to prevent GC
-            const viewer = this.#bookViewer
-            const view = viewer._view
-            let completed = false
-            const handlers = []
-            
-            const cleanup = (success, error) => {
-                if (completed) return
-                completed = true
-                
-                // Disconnect all handlers
-                handlers.forEach(id => {
-                    try {
-                        view.disconnect(id)
-                    } catch (e) {
-                        // Ignore disconnect errors
-                    }
-                })
-                handlers.length = 0
-                
-                // Schedule resolution after current event loop to avoid GC issues
-                GLib.idle_add(GLib.PRIORITY_LOW, () => {
-                    if (success) resolve()
-                    else if (error) reject(error)
-                    return GLib.SOURCE_REMOVE
-                })
-            }
-            
-            // Use handler array to track connections
-            handlers.push(view.connect('book-ready', () => cleanup(true, null)))
-            handlers.push(view.connect('book-error', () => cleanup(false, new Error('Failed to load book'))))
-            
-            // Timeout
-            GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 30, () => {
-                cleanup(false, new Error('Book loading timed out'))
-                return GLib.SOURCE_REMOVE
-            })
-            
-            // Open the book
-            viewer.open(file)
         })
     }
     importBooks() {

--- a/src/app.js
+++ b/src/app.js
@@ -1,31 +1,33 @@
-import Gtk from 'gi://Gtk'
-import Adw from 'gi://Adw'
-import GObject from 'gi://GObject'
-import GLib from 'gi://GLib'
-import Gio from 'gi://Gio'
-import Gdk from 'gi://Gdk'
-import WebKit from 'gi://WebKit'
-import { gettext as _ } from 'gettext'
-import * as utils from './utils.js'
-import { Library } from './library.js'
-import { BookViewer } from './book-viewer.js'
+import Gtk from "gi://Gtk";
+import Adw from "gi://Adw";
+import GObject from "gi://GObject";
+import GLib from "gi://GLib";
+import Gio from "gi://Gio";
+import Gdk from "gi://Gdk";
+import GdkPixbuf from "gi://GdkPixbuf";
+import WebKit from "gi://WebKit";
+import { gettext as _ } from "gettext";
+import * as utils from "./utils.js";
+import { Library, getURIStore, getBookList } from "./library.js";
+import { BookViewer } from "./book-viewer.js";
+import { WebView } from "./webview.js";
 
-const formatVersion = (a, b, c) => `${a ?? '?'}.${b ?? '?'}.${c ?? '?'}`
+const formatVersion = (a, b, c) => `${a ?? "?"}.${b ?? "?"}.${c ?? "?"}`;
 
-const getImportVersion = lib =>
-    formatVersion(lib.MAJOR_VERSION, lib.MINOR_VERSION, lib.MICRO_VERSION)
+const getImportVersion = (lib) =>
+  formatVersion(lib.MAJOR_VERSION, lib.MINOR_VERSION, lib.MICRO_VERSION);
 
 const getGJSVersion = () => {
-    const [a, b, c, d, e] = imports.system.version.toString()
-    return formatVersion(a, b + c, d + e)
-}
+  const [a, b, c, d, e] = imports.system.version.toString();
+  return formatVersion(a, b + c, d + e);
+};
 
 const getDebugInfo = () => {
-    try {
-        return `System: ${GLib.get_os_info('NAME') ?? 'Unknown'} ${GLib.get_os_info('VERSION') ?? GLib.get_os_info('BUILD_ID') ?? ''}
-Desktop: ${GLib.getenv('XDG_CURRENT_DESKTOP') ?? 'Unknown'}
-Session: ${GLib.getenv('XDG_SESSION_DESKTOP') ?? 'UNknown'} (${GLib.getenv('XDG_SESSION_TYPE') ?? 'Unknown'})
-Language: ${GLib.getenv('LANG') ?? 'Unknown'}
+  try {
+    return `System: ${GLib.get_os_info("NAME") ?? "Unknown"} ${GLib.get_os_info("VERSION") ?? GLib.get_os_info("BUILD_ID") ?? ""}
+Desktop: ${GLib.getenv("XDG_CURRENT_DESKTOP") ?? "Unknown"}
+Session: ${GLib.getenv("XDG_SESSION_DESKTOP") ?? "UNknown"} (${GLib.getenv("XDG_SESSION_TYPE") ?? "Unknown"})
+Language: ${GLib.getenv("LANG") ?? "Unknown"}
 
 Versions:
 - Foliate ${pkg.version}
@@ -38,407 +40,633 @@ Versions:
 User directories:
 - ${GLib.get_user_data_dir()}
 - ${GLib.get_user_cache_dir()}
-`
-    } catch (e) {
-        console.error(e)
-        return ''
-    }
-}
+`;
+  } catch (e) {
+    console.error(e);
+    return "";
+  }
+};
 
 // Shared constants for ebook file types
 const EBOOK_MIME_TYPES = [
-    'application/epub+zip',
-    'application/x-mobipocket-ebook',
-    'application/vnd.amazon.mobi8-ebook',
-    'application/x-mobi8-ebook',
-    'application/x-fictionbook+xml',
-    'application/x-zip-compressed-fb2',
-    'application/vnd.comicbook+zip',
-    'application/vnd.comicbook-rar',
-    'application/x-cbr',
-    'application/x-cbz',
-    'application/x-cb7',
-    'application/x-cbt',
-]
+  "application/epub+zip",
+  "application/x-mobipocket-ebook",
+  "application/vnd.amazon.mobi8-ebook",
+  "application/x-mobi8-ebook",
+  "application/x-fictionbook+xml",
+  "application/x-zip-compressed-fb2",
+  "application/vnd.comicbook+zip",
+  "application/vnd.comicbook-rar",
+  "application/x-cbr",
+  "application/x-cbz",
+  "application/x-cb7",
+  "application/x-cbt",
+];
 
 const isEbookFile = (file) => {
-    try {
-        const path = file.get_path()
-        if (!path) {
-            console.debug('File has no path, cannot determine type')
-            return false
-        }
-        
-        // Try MIME type detection first
-        const [mimeType, _certain] = Gio.content_type_guess(path, null)
-        if (mimeType && EBOOK_MIME_TYPES.includes(mimeType)) {
-            return true
-        }
-        
-        return false
-    } catch (e) {
-        console.warn(`Failed to check if file is an ebook (${file.get_uri()}): ${e}`)
-        return false
+  try {
+    const path = file.get_path();
+    if (!path) {
+      console.debug("File has no path, cannot determine type");
+      return false;
     }
-}
 
-const ApplicationWindow = GObject.registerClass({
-    GTypeName: 'FoliateApplicationWindow',
+    // Try MIME type detection first
+    const [mimeType, _certain] = Gio.content_type_guess(path, null);
+    if (mimeType && EBOOK_MIME_TYPES.includes(mimeType)) {
+      return true;
+    }
+
+    return false;
+  } catch (e) {
+    console.warn(
+      `Failed to check if file is an ebook (${file.get_uri()}): ${e}`,
+    );
+    return false;
+  }
+};
+
+const ApplicationWindow = GObject.registerClass(
+  {
+    GTypeName: "FoliateApplicationWindow",
     Properties: utils.makeParams({
-        'file': 'object',
+      file: "object",
     }),
-}, class extends Adw.ApplicationWindow {
-    #library
-    #bookViewer
-    #stack = new Gtk.Stack()
-    #cookie
+  },
+  class extends Adw.ApplicationWindow {
+    #library;
+    #bookViewer;
+    #stack = new Gtk.Stack();
+    #cookie;
     constructor(params) {
-        super(params)
-        Object.assign(this, {
-            handle_menubar_accel: false,
-            title: pkg.localeName,
-            default_width: 1200,
-            default_height: 750,
-            content: new Adw.ToastOverlay({ child: this.#stack }),
-        })
+      super(params);
+      Object.assign(this, {
+        handle_menubar_accel: false,
+        title: pkg.localeName,
+        default_width: 1200,
+        default_height: 750,
+        content: new Adw.ToastOverlay({ child: this.#stack }),
+      });
 
-        const styleManager = Adw.StyleManager.get_default()
-        if (styleManager.dark) this.add_css_class('is-dark')
-        const handler = styleManager.connect('notify::dark', ({ dark }) => {
-            if (dark) this.add_css_class('is-dark')
-            else this.remove_css_class('is-dark')
-        })
-        this.connect('destroy', () => styleManager.disconnect(handler))
+      const styleManager = Adw.StyleManager.get_default();
+      if (styleManager.dark) this.add_css_class("is-dark");
+      const handler = styleManager.connect("notify::dark", ({ dark }) => {
+        if (dark) this.add_css_class("is-dark");
+        else this.remove_css_class("is-dark");
+      });
+      this.connect("destroy", () => styleManager.disconnect(handler));
 
-        utils.addMethods(this, {
-            actions: ['open', 'close', 'show-library', 'show-menu', 'new-window', 'open-copy', 'import-books'],
-            props: ['fullscreened'],
-        })
+      utils.addMethods(this, {
+        actions: [
+          "open",
+          "close",
+          "show-library",
+          "show-menu",
+          "new-window",
+          "open-copy",
+          "import-books",
+        ],
+        props: ["fullscreened"],
+      });
 
-        utils.bindSettings('window', this,
-            ['default-width', 'default-height', 'maximized', 'fullscreened'])
+      utils.bindSettings("window", this, [
+        "default-width",
+        "default-height",
+        "maximized",
+        "fullscreened",
+      ]);
 
+      this.connect("notify::fullscreened", (win) => {
+        let app = Gio.Application.get_default();
+        if (this.is_fullscreen()) {
+          this.#cookie = app.inhibit(
+            win,
+            Gtk.ApplicationInhibitFlags.IDLE,
+            "Reading book in fullscreen",
+          );
+          if (this.#cookie == 0)
+            console.error("Failed to inhibit session idle");
+        } else if (this.#cookie > 0) {
+          app.uninhibit(this.#cookie);
+        }
+      });
 
-        this.connect('notify::fullscreened', (win) => {
-            let app = Gio.Application.get_default()
-            if (this.is_fullscreen()) {
-                this.#cookie = app.inhibit(win, Gtk.ApplicationInhibitFlags.IDLE,
-                    'Reading book in fullscreen')
-                if (this.#cookie == 0)
-                    console.error('Failed to inhibit session idle')
-            } else if (this.#cookie > 0) {
-                app.uninhibit(this.#cookie)
-            }
-        })
-
-        if (this.file) this.openFile(this.file)
-        else this.showLibrary()
+      if (this.file) this.openFile(this.file);
+      else this.showLibrary();
     }
     add_toast(toast) {
-        this.content.add_toast(toast)
+      this.content.add_toast(toast);
     }
     error(heading, body) {
-        const dialog = new Adw.AlertDialog({
-            heading, body,
-        })
-        dialog.add_response('close', _('Close'))
-        dialog.present(this)
+      const dialog = new Adw.AlertDialog({
+        heading,
+        body,
+      });
+      dialog.add_response("close", _("Close"));
+      dialog.present(this);
     }
     actionDialog() {
-        const window = new Adw.Window({
-            modal: true,
-            transient_for: this.root,
-            content: new Adw.ToolbarView(),
-            default_width: 400,
-        })
-        window.add_controller(utils.addShortcuts({ 'Escape|<ctrl>w': () => window.close() }))
-        const header = new Adw.HeaderBar({
-            show_title: false,
-            show_start_title_buttons: false,
-            show_end_title_buttons: false,
-        })
-        header.pack_start(utils.connect(new Gtk.Button({
-            label: _('Cancel'),
-        }), { 'clicked': () => window.close() }))
-        const button = utils.addClass(new Gtk.Button(), 'suggested-action')
-        header.pack_end(button)
-        window.content.add_top_bar(header)
-        return { button, window }
+      const window = new Adw.Window({
+        modal: true,
+        transient_for: this.root,
+        content: new Adw.ToolbarView(),
+        default_width: 400,
+      });
+      window.add_controller(
+        utils.addShortcuts({ "Escape|<ctrl>w": () => window.close() }),
+      );
+      const header = new Adw.HeaderBar({
+        show_title: false,
+        show_start_title_buttons: false,
+        show_end_title_buttons: false,
+      });
+      header.pack_start(
+        utils.connect(
+          new Gtk.Button({
+            label: _("Cancel"),
+          }),
+          { clicked: () => window.close() },
+        ),
+      );
+      const button = utils.addClass(new Gtk.Button(), "suggested-action");
+      header.pack_end(button);
+      window.content.add_top_bar(header);
+      return { button, window };
     }
     openFile(file) {
-        this.file = file
-        if (!this.#bookViewer) {
-            this.#bookViewer = new BookViewer()
-            this.#stack.add_child(this.#bookViewer)
-        }
-        this.#stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT
-        this.#stack.visible_child = this.#bookViewer
-        this.#bookViewer.open(file)
+      this.file = file;
+      if (!this.#bookViewer) {
+        this.#bookViewer = new BookViewer();
+        this.#stack.add_child(this.#bookViewer);
+      }
+      this.#stack.transition_type = Gtk.StackTransitionType.SLIDE_LEFT;
+      this.#stack.visible_child = this.#bookViewer;
+      this.#bookViewer.open(file);
     }
     openOPDS(uri) {
-        this.showLibrary()
-        this.#library.showCatalog(uri)
+      this.showLibrary();
+      this.#library.showCatalog(uri);
     }
     open() {
-        const dialog = new Gtk.FileDialog()
-        const ebooks = new Gtk.FileFilter({
-            name: _('E-Book Files'),
-            mime_types: EBOOK_MIME_TYPES,
-        })
-        dialog.filters = new Gio.ListStore()
-        dialog.filters.append(new Gtk.FileFilter({
-            name: _('All Files'),
-            patterns: ['*'],
-        }))
-        dialog.filters.append(ebooks)
-        dialog.default_filter = ebooks
-        dialog.open(this, null, (_, res) => {
-            try {
-                const file = dialog.open_finish(res)
-                this.openFile(file)
-            } catch (e) {
-                if (e instanceof Gtk.DialogError) console.debug(e)
-                else console.error(e)
-            }
-        })
+      const dialog = new Gtk.FileDialog();
+      const ebooks = new Gtk.FileFilter({
+        name: _("E-Book Files"),
+        mime_types: EBOOK_MIME_TYPES,
+      });
+      dialog.filters = new Gio.ListStore();
+      dialog.filters.append(
+        new Gtk.FileFilter({
+          name: _("All Files"),
+          patterns: ["*"],
+        }),
+      );
+      dialog.filters.append(ebooks);
+      dialog.default_filter = ebooks;
+      dialog.open(this, null, (_, res) => {
+        try {
+          const file = dialog.open_finish(res);
+          this.openFile(file);
+        } catch (e) {
+          if (e instanceof Gtk.DialogError) console.debug(e);
+          else console.error(e);
+        }
+      });
     }
     #collectEbooksFromDirectory(directory, files = []) {
-        try {
-            const enumerator = directory.enumerate_children(
-                'standard::name,standard::type',
-                Gio.FileQueryInfoFlags.NONE,
-                null,
-            )
-            let info
-            while ((info = enumerator.next_file(null))) {
-                const name = info.get_name()
-                
-                // Skip hidden files and macOS resource forks
-                if (name.startsWith('.')) continue
-                
-                const child = directory.get_child(name)
-                const fileType = info.get_file_type()
+      try {
+        const enumerator = directory.enumerate_children(
+          "standard::name,standard::type",
+          Gio.FileQueryInfoFlags.NONE,
+          null,
+        );
+        let info;
+        while ((info = enumerator.next_file(null))) {
+          const name = info.get_name();
 
-                if (fileType === Gio.FileType.DIRECTORY) {
-                    this.#collectEbooksFromDirectory(child, files)
-                } else if (fileType === Gio.FileType.REGULAR) {
-                    // Use content_type_guess instead of file extensions
-                    if (isEbookFile(child)) {
-                        files.push(child)
-                    }
-                }
+          // Skip hidden files and macOS resource forks
+          if (name.startsWith(".")) continue;
+
+          const child = directory.get_child(name);
+          const fileType = info.get_file_type();
+
+          if (fileType === Gio.FileType.DIRECTORY) {
+            this.#collectEbooksFromDirectory(child, files);
+          } else if (fileType === Gio.FileType.REGULAR) {
+            // Use content_type_guess instead of file extensions
+            if (isEbookFile(child)) {
+              files.push(child);
             }
-            enumerator.close(null)
-        } catch (e) {
-            console.warn(`Failed to read directory ${directory.get_path()}: ${e}`)
+          }
         }
-        return files
+        enumerator.close(null);
+      } catch (e) {
+        console.warn(`Failed to read directory ${directory.get_path()}: ${e}`);
+      }
+      return files;
     }
-    #importFilesInBackground(files) {
-        // Import files by adding them to the library without rendering
-        // Just store the file URIs - metadata will be extracted when books are first opened
-        let toast = new Adw.Toast({
-            title: files.length === 1
-                ? _('Importing 1 book…')
-                : _(`Importing ${files.length} books…`),
-            timeout: 0,
-        })
-        this.add_toast(toast)
-        
-        // Show library view immediately
-        this.showLibrary()
-        
-        // Import each file by just opening it once to trigger metadata extraction
-        // but do it in the hidden bookviewer to avoid visual flashing
-        let currentIndex = 0
-        let hiddenViewer = null
-        
-        const importNext = () => {
-            if (currentIndex >= files.length) {
-                // Clean up
-                if (hiddenViewer) {
-                    this.#stack.remove(hiddenViewer)
-                    hiddenViewer = null
-                }
-                toast.dismiss()
-                
-                const finalToast = new Adw.Toast({
-                    title: files.length === 1
-                        ? _('Imported 1 book')
-                        : _(`Imported ${files.length} books`),
-                })
-                this.add_toast(finalToast)
-                return
-            }
-            
-            const file = files[currentIndex]
-            currentIndex++
-            
-            // Update toast with current progress
-            if (files.length > 1) {
-                toast.title = _(`Importing ${currentIndex} of ${files.length} books…`)
-            }
-            
-            // Create hidden viewer if needed
-            if (!hiddenViewer) {
-                hiddenViewer = new BookViewer()
-                this.#stack.add_child(hiddenViewer)
-                // Keep library visible
-            }
-            
-            // Open file in hidden viewer to extract metadata
-            hiddenViewer.open(file)
-            
-            // Continue with next file after a delay
-            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
-                importNext()
-                return GLib.SOURCE_REMOVE
-            })
+    #headlessViewer;
+    async #initHeadlessViewer() {
+      if (this.#headlessViewer) return;
+      this.#headlessViewer = new WebView({
+        settings: new WebKit.Settings({
+          enable_write_console_messages_to_stdout: true,
+          enable_developer_extras: true,
+          allow_file_access_from_file_urls: true,
+          allow_universal_access_from_file_urls: true,
+        }),
+      });
+      await this.#headlessViewer.loadURI(pkg.moduleuri("reader/metadata.html"));
+      // Wait for the script to load
+      for (let i = 0; i < 50; i++) {
+        if (
+          await this.#headlessViewer.eval('typeof getMetadata === "function"')
+        )
+          return;
+        await utils.wait(100);
+      }
+      console.error("Failed to load metadata script");
+    }
+
+    #makeMetadataPayload(file) {
+      const path = file.get_path();
+      if (!path) return { uri: file.get_uri() };
+      try {
+        const [success, contents] = file.load_contents(null);
+        if (!success) throw new Error("Failed to read file contents");
+        let mimeType = "";
+        try {
+          const info = file.query_info(
+            "standard::content-type",
+            Gio.FileQueryInfoFlags.NONE,
+            null,
+          );
+          mimeType = info?.get_content_type() ?? "";
+        } catch (infoError) {
+          console.debug(infoError);
         }
-        
-        importNext()
+        const data = GLib.base64_encode(contents);
+        return {
+          data,
+          name: file.get_basename(),
+          mimeType,
+        };
+      } catch (e) {
+        console.error(
+          `Failed to read ${file.get_uri()} for metadata import: ${e}`,
+        );
+        return { uri: file.get_uri() };
+      }
+    }
+
+    #writeBookMetadata(key, metadata) {
+      const encoded = encodeURIComponent(key);
+      const path = GLib.build_filenamev([pkg.datadir, `${encoded}.json`]);
+      const file = Gio.File.new_for_path(path);
+      const parent = file.get_parent();
+      try {
+        GLib.mkdir_with_parents(parent.get_path(), parseInt("0755", 8));
+      } catch (mkdirError) {
+        console.error(`Failed to create metadata directory: ${mkdirError}`);
+      }
+      let existing = {};
+      if (file.query_exists(null)) {
+        try {
+          existing = utils.readJSONFile(file);
+        } catch (readError) {
+          console.warn(
+            `Failed to read existing metadata for ${key}: ${readError}`,
+          );
+        }
+      }
+      existing.metadata = metadata;
+      const contents = JSON.stringify(existing);
+      try {
+        const [success] = file.replace_contents(
+          contents,
+          null,
+          false,
+          Gio.FileCreateFlags.REPLACE_DESTINATION,
+          null,
+        );
+        if (!success) throw new Error("replace_contents returned false");
+      } catch (writeError) {
+        console.error(
+          `Failed to write book metadata for ${key}: ${writeError}`,
+        );
+        throw writeError;
+      }
+      return path;
+    }
+
+    #removeBookMetadata(identifier) {
+      if (!identifier) return;
+      const encoded = encodeURIComponent(identifier);
+      const path = GLib.build_filenamev([pkg.datadir, `${encoded}.json`]);
+      const file = Gio.File.new_for_path(path);
+      const list = getBookList();
+      if (list && file.query_exists(null)) {
+        list.delete(file);
+        return;
+      }
+      try {
+        if (file.query_exists(null)) file.delete(null);
+      } catch (e) {
+        console.debug(`Failed to remove metadata for ${identifier}: ${e}`);
+      }
+      const coverPath = pkg.cachepath(`${encoded}.png`);
+      const coverFile = Gio.File.new_for_path(coverPath);
+      try {
+        if (coverFile.query_exists(null)) coverFile.delete(null);
+      } catch (e) {
+        console.debug(`Failed to remove cover for ${identifier}: ${e}`);
+      }
+      getURIStore().delete(identifier);
+    }
+
+    async #importFilesInBackground(files) {
+      const toast = new Adw.Toast({
+        title:
+          files.length === 1
+            ? _("Importing 1 book…")
+            : _(`Importing ${files.length} books…`),
+        timeout: 0,
+      });
+      this.add_toast(toast);
+      this.showLibrary();
+
+      await this.#initHeadlessViewer();
+
+      const settings = utils.settings("library");
+      const showCovers = settings?.get_boolean("show-covers") ?? true;
+      const coverSize = settings?.get_int("cover-size") ?? 256;
+      const homeDir = GLib.get_home_dir();
+
+      let count = 0;
+      for (const file of files) {
+        count++;
+        if (files.length > 1) {
+          toast.title = _(`Importing ${count} of ${files.length} books…`);
+        }
+
+        try {
+          const checksum = utils.makeIdentifier(file);
+          if (!checksum) {
+            console.warn(`Could not generate identifier for ${file.get_uri()}`);
+            continue;
+          }
+
+          const payload = this.#makeMetadataPayload(file);
+          const result = await this.#headlessViewer.exec(
+            "getMetadata",
+            payload,
+          );
+          if ("data" in payload) payload.data = null;
+          if (!result) throw new Error("No metadata returned");
+          const metadata = result.metadata ?? {};
+          const originalIdentifier =
+            typeof metadata.identifier === "string"
+              ? metadata.identifier
+              : null;
+          const cover = result.cover;
+
+          const key = originalIdentifier || checksum;
+
+          const existingAltIdentifiers = Array.isArray(metadata.altIdentifier)
+            ? metadata.altIdentifier
+            : metadata.altIdentifier
+              ? [metadata.altIdentifier]
+              : [];
+          const altIdentifiers = [];
+
+          metadata.identifier = key;
+          if (checksum !== key) {
+            altIdentifiers.push(checksum);
+            this.#removeBookMetadata(checksum);
+          }
+          for (const id of existingAltIdentifiers) {
+            if (typeof id !== "string") continue;
+            if (id === key) continue;
+            if (!altIdentifiers.includes(id)) altIdentifiers.push(id);
+          }
+          if (altIdentifiers.length) metadata.altIdentifier = altIdentifiers;
+          else delete metadata.altIdentifier;
+
+          const metadataPath = this.#writeBookMetadata(key, metadata);
+
+          if (showCovers && cover) {
+            try {
+              const bytes = GLib.base64_decode(cover);
+              const loader = new GdkPixbuf.PixbufLoader();
+              if (!loader.write(bytes))
+                throw new Error("Failed to decode cover data");
+              loader.close();
+              const pixbuf = loader.get_pixbuf();
+              if (!pixbuf) throw new Error("Cover pixbuf unavailable");
+
+              const path = pkg.cachepath(`${encodeURIComponent(key)}.png`);
+              const coverFile = Gio.File.new_for_path(path);
+              const coverDir = coverFile.get_parent();
+              try {
+                GLib.mkdir_with_parents(
+                  coverDir.get_path(),
+                  parseInt("0755", 8),
+                );
+              } catch (coverMkdirError) {
+                console.error(
+                  `Failed to create cover directory: ${coverMkdirError}`,
+                );
+              }
+              const ratio = coverSize / pixbuf.get_width();
+
+              const scaled =
+                ratio >= 1
+                  ? pixbuf
+                  : pixbuf.scale_simple(
+                      coverSize,
+                      Math.round(pixbuf.get_height() * ratio),
+                      GdkPixbuf.InterpType.BILINEAR,
+                    );
+
+              scaled.savev(path, "png", [], []);
+            } catch (e) {
+              console.warn("Failed to save cover", e);
+            }
+          }
+
+          const path = file.get_path();
+          getURIStore().set(
+            key,
+            path?.startsWith(homeDir)
+              ? path.replace(homeDir, "~")
+              : file.get_uri(),
+          );
+
+          if (metadataPath) getBookList()?.update(metadataPath);
+        } catch (e) {
+          console.error(`Failed to import ${file.get_uri()}: ${e}`);
+        }
+        await utils.wait(0);
+      }
+
+      toast.dismiss();
+      this.add_toast(
+        new Adw.Toast({
+          title:
+            files.length === 1
+              ? _("Imported 1 book")
+              : _(`Imported ${files.length} books`),
+        }),
+      );
     }
     #importMultipleFiles() {
-        const dialog = new Gtk.FileDialog()
-        const ebooks = new Gtk.FileFilter({
-            name: _('E-Book Files'),
-            mime_types: EBOOK_MIME_TYPES,
-        })
-        dialog.filters = new Gio.ListStore()
-        dialog.filters.append(new Gtk.FileFilter({
-            name: _('All Files'),
-            patterns: ['*'],
-        }))
-        dialog.filters.append(ebooks)
-        dialog.default_filter = ebooks
+      const dialog = new Gtk.FileDialog();
+      const ebooks = new Gtk.FileFilter({
+        name: _("E-Book Files"),
+        mime_types: EBOOK_MIME_TYPES,
+      });
+      dialog.filters = new Gio.ListStore();
+      dialog.filters.append(
+        new Gtk.FileFilter({
+          name: _("All Files"),
+          patterns: ["*"],
+        }),
+      );
+      dialog.filters.append(ebooks);
+      dialog.default_filter = ebooks;
 
-        dialog.open_multiple(this, null, (_, res) => {
-            try {
-                const gfiles = dialog.open_multiple_finish(res)
-                const files = []
-                for (let i = 0; i < gfiles.get_n_items(); i++) {
-                    files.push(gfiles.get_item(i))
-                }
-                if (files.length > 0) {
-                    this.#importFilesInBackground(files)
-                }
-            } catch (e) {
-                if (e instanceof Gtk.DialogError) console.debug(e)
-                else console.error(e)
-            }
-        })
+      dialog.open_multiple(this, null, (_, res) => {
+        try {
+          const gfiles = dialog.open_multiple_finish(res);
+          const files = [];
+          for (let i = 0; i < gfiles.get_n_items(); i++) {
+            files.push(gfiles.get_item(i));
+          }
+          if (files.length > 0) {
+            this.#importFilesInBackground(files);
+          }
+        } catch (e) {
+          if (e instanceof Gtk.DialogError) console.debug(e);
+          else console.error(e);
+        }
+      });
     }
     #importFromFolder() {
-        const dialog = new Gtk.FileDialog()
-        dialog.select_folder(this, null, (obj, res) => {
-            try {
-                const folder = dialog.select_folder_finish(res)
-                const files = this.#collectEbooksFromDirectory(folder)
-                
-                if (files.length > 0) {
-                    this.#importFilesInBackground(files)
-                } else {
-                    const toast = new Adw.Toast({
-                        title: _('No e-books found in the selected folder'),
-                    })
-                    this.add_toast(toast)
-                }
-            } catch (e) {
-                if (e instanceof Gtk.DialogError) console.debug(e)
-                else console.error(e)
-            }
-        })
+      const dialog = new Gtk.FileDialog();
+      dialog.select_folder(this, null, (obj, res) => {
+        try {
+          const folder = dialog.select_folder_finish(res);
+          const files = this.#collectEbooksFromDirectory(folder);
+
+          if (files.length > 0) {
+            this.#importFilesInBackground(files);
+          } else {
+            const toast = new Adw.Toast({
+              title: _("No e-books found in the selected folder"),
+            });
+            this.add_toast(toast);
+          }
+        } catch (e) {
+          if (e instanceof Gtk.DialogError) console.debug(e);
+          else console.error(e);
+        }
+      });
     }
     importBooks() {
-        const dialog = new Adw.AlertDialog({
-            heading: _('Import Books'),
-            body: _('Choose how you want to import books to your library'),
-        })
-        dialog.add_response('cancel', _('Cancel'))
-        dialog.add_response('files', _('Select Files'))
-        dialog.add_response('folder', _('Select Folder'))
-        dialog.set_response_appearance('files', Adw.ResponseAppearance.SUGGESTED)
-        dialog.choose(this, null, (_, res) => {
-            try {
-                const response = dialog.choose_finish(res)
-                if (response === 'files') this.#importMultipleFiles()
-                else if (response === 'folder') this.#importFromFolder()
-            } catch (e) {
-                if (e instanceof Gtk.DialogError) console.debug(e)
-                else console.error(e)
-            }
-        })
+      const dialog = new Adw.AlertDialog({
+        heading: _("Import Books"),
+        body: _("Choose how you want to import books to your library"),
+      });
+      dialog.add_response("cancel", _("Cancel"));
+      dialog.add_response("files", _("Select Files"));
+      dialog.add_response("folder", _("Select Folder"));
+      dialog.set_response_appearance("files", Adw.ResponseAppearance.SUGGESTED);
+      dialog.choose(this, null, (_, res) => {
+        try {
+          const response = dialog.choose_finish(res);
+          if (response === "files") this.#importMultipleFiles();
+          else if (response === "folder") this.#importFromFolder();
+        } catch (e) {
+          if (e instanceof Gtk.DialogError) console.debug(e);
+          else console.error(e);
+        }
+      });
     }
     showLibrary() {
-        this.file = null
-        this.title = pkg.localeName
-        if (!this.#library) {
-            this.#library = new Library()
-            this.#stack.add_child(this.#library)
-        }
-        this.#stack.transition_type = Gtk.StackTransitionType.SLIDE_RIGHT
-        this.#stack.visible_child = this.#library
-        if (this.#bookViewer) {
-            this.#stack.remove(this.#bookViewer)
-            this.#bookViewer = null
-        }
+      this.file = null;
+      this.title = pkg.localeName;
+      if (!this.#library) {
+        this.#library = new Library();
+        this.#stack.add_child(this.#library);
+      }
+      this.#stack.transition_type = Gtk.StackTransitionType.SLIDE_RIGHT;
+      this.#stack.visible_child = this.#library;
+      if (this.#bookViewer) {
+        this.#stack.remove(this.#bookViewer);
+        this.#bookViewer = null;
+      }
     }
     showMenu() {
-        if (this.#bookViewer) this.#bookViewer.showPrimaryMenu()
+      if (this.#bookViewer) this.#bookViewer.showPrimaryMenu();
     }
     addWindow(file) {
-        const { application } = this
-        const win = new ApplicationWindow({ application, file })
-        new Gtk.WindowGroup().add_window(win)
-        win.present()
+      const { application } = this;
+      const win = new ApplicationWindow({ application, file });
+      new Gtk.WindowGroup().add_window(win);
+      win.present();
     }
     newWindow() {
-        this.addWindow(null)
+      this.addWindow(null);
     }
     openCopy() {
-        this.addWindow(this.file)
+      this.addWindow(this.file);
     }
-})
+  },
+);
 
-export const Application = GObject.registerClass({
-    GTypeName: 'FoliateApplication',
-}, class extends Adw.Application {
+export const Application = GObject.registerClass(
+  {
+    GTypeName: "FoliateApplication",
+  },
+  class extends Adw.Application {
     constructor(params) {
-        super(params)
-        this.application_id = pkg.name
-        this.flags = Gio.ApplicationFlags.HANDLES_OPEN
+      super(params);
+      this.application_id = pkg.name;
+      this.flags = Gio.ApplicationFlags.HANDLES_OPEN;
 
-        utils.addMethods(this, {
-            actions: ['about', 'quit'],
-            signals: ['startup', 'activate', 'open', 'window-removed'],
-        })
+      utils.addMethods(this, {
+        actions: ["about", "quit"],
+        signals: ["startup", "activate", "open", "window-removed"],
+      });
 
-        for (const [key, val] of Object.entries({
-            'app.quit': ['<ctrl>q'],
-            'app.about': ['F1'],
-            'win.close': ['<ctrl>w'],
-            'win.fullscreened': ['F11'],
-            'win.show-menu': ['F10'],
-            'win.open': ['<ctrl>o'],
-            'win.open-copy': ['<ctrl>n'],
-            'win.import-books': ['<ctrl><shift>o'],
-        })) this.set_accels_for_action(key, val)
+      for (const [key, val] of Object.entries({
+        "app.quit": ["<ctrl>q"],
+        "app.about": ["F1"],
+        "win.close": ["<ctrl>w"],
+        "win.fullscreened": ["F11"],
+        "win.show-menu": ["F10"],
+        "win.open": ["<ctrl>o"],
+        "win.open-copy": ["<ctrl>n"],
+        "win.import-books": ["<ctrl><shift>o"],
+      }))
+        this.set_accels_for_action(key, val);
     }
     connectStartup() {
-        const settings = utils.settings()
-        if (settings) {
-            const styleManager = Adw.StyleManager.get_default()
-            styleManager.color_scheme = settings.get_int('color-scheme')
-            styleManager.connect('notify::color-scheme', () =>
-                settings.set_int('color-scheme', styleManager.color_scheme))
-        }
+      const settings = utils.settings();
+      if (settings) {
+        const styleManager = Adw.StyleManager.get_default();
+        styleManager.color_scheme = settings.get_int("color-scheme");
+        styleManager.connect("notify::color-scheme", () =>
+          settings.set_int("color-scheme", styleManager.color_scheme),
+        );
+      }
 
-        const theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
-        if (pkg.useResource) theme.add_resource_path(pkg.modulepath('/icons'))
-        else theme.add_search_path(pkg.modulepath('/icons'))
+      const theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default());
+      if (pkg.useResource) theme.add_resource_path(pkg.modulepath("/icons"));
+      else theme.add_search_path(pkg.modulepath("/icons"));
 
-        const cssProvider = new Gtk.CssProvider()
-        cssProvider.load_from_data(`
+      const cssProvider = new Gtk.CssProvider();
+      cssProvider.load_from_data(
+        `
             gridview {
                 padding: 12px;
             }
@@ -550,80 +778,94 @@ export const Application = GObject.registerClass({
             progress, trough {
                 min-width: 1px;
             }
-        `, -1)
-        Gtk.StyleContext.add_provider_for_display(
-            Gdk.Display.get_default(),
-            cssProvider,
-            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        `,
+        -1,
+      );
+      Gtk.StyleContext.add_provider_for_display(
+        Gdk.Display.get_default(),
+        cssProvider,
+        Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+      );
     }
     connectActivate(application) {
-        if (this.activeWindow) {
-            this.activeWindow.present()
-            return
-        }
-        const win = new ApplicationWindow({ application })
-        new Gtk.WindowGroup().add_window(win)
-        win.present()
+      if (this.activeWindow) {
+        this.activeWindow.present();
+        return;
+      }
+      const win = new ApplicationWindow({ application });
+      new Gtk.WindowGroup().add_window(win);
+      win.present();
     }
     connectOpen(application, files) {
-        const oldWins = this.get_windows()
-        file: for (const file of files) {
-            if (file.get_uri_scheme() === 'opds') {
-                const oldWin = oldWins.find(win => !win.file)
-                const uri = file.get_uri()
-                if (oldWin) oldWin.openOPDS(uri)
-                else {
-                    const win = new ApplicationWindow({ application })
-                    new Gtk.WindowGroup().add_window(win)
-                    win.openOPDS(uri)
-                    win.present()
-                }
-                continue
+      const oldWins = this.get_windows();
+      file: for (const file of files) {
+        if (file.get_uri_scheme() === "opds") {
+          const oldWin = oldWins.find((win) => !win.file);
+          const uri = file.get_uri();
+          if (oldWin) oldWin.openOPDS(uri);
+          else {
+            const win = new ApplicationWindow({ application });
+            new Gtk.WindowGroup().add_window(win);
+            win.openOPDS(uri);
+            win.present();
+          }
+          continue;
+        } else
+          for (const oldWin of oldWins) {
+            if (oldWin.file?.get_uri() === file.get_uri()) {
+              oldWin.present();
+              continue file;
             }
-            else for (const oldWin of oldWins) {
-                if (oldWin.file?.get_uri() === file.get_uri()) {
-                    oldWin.present()
-                    continue file
-                }
-            }
-            const win = new ApplicationWindow({ application, file })
-            new Gtk.WindowGroup().add_window(win)
-            win.present()
-        }
+          }
+        const win = new ApplicationWindow({ application, file });
+        new Gtk.WindowGroup().add_window(win);
+        win.present();
+      }
     }
     connectWindowRemoved(application, window) {
-        // this seems to be needed for destroying the web view
-        window.run_dispose()
+      // this seems to be needed for destroying the web view
+      window.run_dispose();
     }
     about() {
-        const win = new Adw.AboutDialog({
-            application_name: pkg.localeName,
-            application_icon: pkg.name,
-            version: pkg.version,
-            comments: _('Read e-books in style'),
-            developer_name: 'John Factotum',
-            developers: ['John Factotum'],
-            artists: ['John Factotum', 'Tobias Bernard <tbernard@gnome.org>'],
-            // Translators: put your names here, one name per line
-            // they will be shown in the "About" dialog
-            translator_credits: _('translator-credits'),
-            license_type: Gtk.License.GPL_3_0,
-            website: 'https://johnfactotum.github.io/foliate/',
-            issue_url: 'https://github.com/johnfactotum/foliate/issues',
-            support_url: 'https://github.com/johnfactotum/foliate/blob/gtk4/docs/faq.md',
-            debug_info: getDebugInfo(),
-        })
-        win.add_link(_('Source Code'), 'https://github.com/johnfactotum/foliate')
-        win.add_legal_section('foliate-js', null, Gtk.License.MIT_X11, null)
-        win.add_legal_section('zip.js',
-            'Copyright © 2022 Gildas Lormeau',
-            Gtk.License.BSD_3, null)
-        win.add_legal_section('fflate',
-            'Copyright © 2020 Arjun Barrett',
-            Gtk.License.MIT_X11, null)
-        win.add_legal_section('PDF.js',
-            '©Mozilla and individual contributors',
-            Gtk.License.APACHE_2_0, null)
-        win.present(this.active_window)
+      const win = new Adw.AboutDialog({
+        application_name: pkg.localeName,
+        application_icon: pkg.name,
+        version: pkg.version,
+        comments: _("Read e-books in style"),
+        developer_name: "John Factotum",
+        developers: ["John Factotum"],
+        artists: ["John Factotum", "Tobias Bernard <tbernard@gnome.org>"],
+        // Translators: put your names here, one name per line
+        // they will be shown in the "About" dialog
+        translator_credits: _("translator-credits"),
+        license_type: Gtk.License.GPL_3_0,
+        website: "https://johnfactotum.github.io/foliate/",
+        issue_url: "https://github.com/johnfactotum/foliate/issues",
+        support_url:
+          "https://github.com/johnfactotum/foliate/blob/gtk4/docs/faq.md",
+        debug_info: getDebugInfo(),
+      });
+      win.add_link(_("Source Code"), "https://github.com/johnfactotum/foliate");
+      win.add_legal_section("foliate-js", null, Gtk.License.MIT_X11, null);
+      win.add_legal_section(
+        "zip.js",
+        "Copyright © 2022 Gildas Lormeau",
+        Gtk.License.BSD_3,
+        null,
+      );
+      win.add_legal_section(
+        "fflate",
+        "Copyright © 2020 Arjun Barrett",
+        Gtk.License.MIT_X11,
+        null,
+      );
+      win.add_legal_section(
+        "PDF.js",
+        "©Mozilla and individual contributors",
+        Gtk.License.APACHE_2_0,
+        null,
+      );
+      win.present(this.active_window);
     }
-})
+  },
+);

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -742,7 +742,7 @@ export const BookViewer = GObject.registerClass({
         this._book_title.label = formatLanguageMap(book.metadata.title)
         this._book_author.label = formatAuthors(book.metadata)
         this._book_author.visible = !!this._book_author.label
-        this.root.title = this._book_title.label
+        if (this.root) this.root.title = this._book_title.label
 
         const { language: { direction } } = reader.view
         utils.setDirection(this._book_info, direction)
@@ -1004,6 +1004,7 @@ export const BookViewer = GObject.registerClass({
         importAnnotations(this.root, this.#data)
     }
     vfunc_unroot() {
+        if (!this.#data) return
         this._navbar.tts_box.kill()
         this._view.viewSettings.unbindSettings()
         this._view.fontSettings.unbindSettings()

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -169,7 +169,6 @@ GObject.registerClass({
             enable_write_console_messages_to_stdout: true,
             enable_developer_extras: true,
             enable_back_forward_navigation_gestures: false,
-            enable_hyperlink_auditing: false,
             enable_html5_database: false,
             enable_html5_local_storage: false,
             enable_smooth_scrolling: false,
@@ -429,20 +428,6 @@ const autohide = (revealer, shouldStayVisible) => {
     revealer.add_controller(utils.connect(
         new Gtk.GestureClick(), { 'pressed': show }))
     return { show, hide, sync }
-}
-
-const makeIdentifier = file => {
-    try {
-        const stream = file.read(null)
-        // 10000000 might not be the best value but I guess we will stick to it
-        // for compatibility with previous versions
-        const bytes = stream.read_bytes(10000000, null)
-        const md5 = GLib.compute_checksum_for_bytes(GLib.ChecksumType.MD5, bytes)
-        return `foliate:${md5}`
-    } catch(e) {
-        console.warn(e)
-        return null
-    }
 }
 
 export const BookViewer = GObject.registerClass({
@@ -772,7 +757,7 @@ export const BookViewer = GObject.registerClass({
             this._book_cover.hide()
         }
 
-        book.metadata.identifier ||= makeIdentifier(this.#file)
+        book.metadata.identifier ||= utils.makeIdentifier(this.#file)
         const { identifier } = book.metadata
         if (identifier) {
             this.#data = await dataStore.get(identifier, this._view)

--- a/src/gresource.xml
+++ b/src/gresource.xml
@@ -264,6 +264,8 @@
     <file>selection-tools/wiktionary.html</file>
     <file>common/widgets.js</file>
     <file>reader/markup.js</file>
+    <file>reader/metadata.html</file>
+    <file>reader/metadata.js</file>
     <file>reader/reader.html</file>
     <file>reader/reader.js</file>
   </gresource>

--- a/src/library.js
+++ b/src/library.js
@@ -910,6 +910,11 @@ export const Library = GObject.registerClass({
         this.insert_action_group('library', this._books_view.actionGroup)
         this.insert_action_group('catalog', this._opds_view.actionGroup)
     }
+    vfunc_dispose() {
+        // Clear the header function to prevent callbacks during shutdown
+        this._sidebar_list_box.set_header_func(null)
+        super.vfunc_dispose()
+    }
     #addCatalog(url) {
         this._sidebar_list_box.select_row(null)
         const handler = this._opds_view.connect('state-changed', (_, state) => {

--- a/src/library.js
+++ b/src/library.js
@@ -79,25 +79,52 @@ const uiText = {
     },
 }
 
+let trackerModule
+let trackerUnavailable = false
+
+const getTrackerModule = () => {
+    if (trackerUnavailable) return null
+    if (!trackerModule) {
+        try {
+            trackerModule = imports.gi.Tracker
+        } catch (e) {
+            console.debug(e)
+            trackerUnavailable = true
+            return null
+        }
+    }
+    return trackerModule
+}
+
 const getURIFromTracker = identifier => {
-    const connection = imports.gi.Tracker.SparqlConnection.bus_new(
-        'org.freedesktop.Tracker3.Miner.Files', null, null)
-    const statement = connection.query_statement(`
-        SELECT ?uri
-        WHERE {
-            GRAPH tracker:Documents {
-                ?u rdf:type nfo:EBook .
-                ?u nie:isStoredAs ?uri .
-                ?u nie:identifier ~identifier .
-            }
-        }`, null)
-    statement.bind_string('identifier', identifier)
-    const cursor = statement.execute(null)
-    cursor.next(null)
-    const uri = cursor.get_string(0)[0]
-    cursor.close()
-    connection.close()
-    return uri
+    const Tracker = getTrackerModule()
+    if (!Tracker?.SparqlConnection) return null
+    let connection
+    try {
+        connection = Tracker.SparqlConnection.bus_new(
+            'org.freedesktop.Tracker3.Miner.Files', null, null)
+        const statement = connection.query_statement(`
+            SELECT ?uri
+            WHERE {
+                GRAPH tracker:Documents {
+                    ?u rdf:type nfo:EBook .
+                    ?u nie:isStoredAs ?uri .
+                    ?u nie:identifier ~identifier .
+                }
+            }`, null)
+        statement.bind_string('identifier', identifier)
+        const cursor = statement.execute(null)
+        cursor.next(null)
+        const uri = cursor.get_string(0)?.[0]
+        cursor.close()
+        return uri
+    } catch (e) {
+        console.debug(e)
+        trackerUnavailable = true
+        return null
+    } finally {
+        connection?.close()
+    }
 }
 
 const showCovers = utils.settings('library')?.get_boolean('show-covers') ?? true
@@ -185,7 +212,10 @@ const BookList = GObject.registerClass({
         // set to null instead of removing it so we don't mess up the iterator
         if (i !== -1) this.#files[i] = null
         // remove it from the list if it has been loaded
-        for (const [i, el] of utils.gliter(this)) if (el.get_path() === path) this.remove(i)
+        for (let j = this.get_n_items() - 1; j >= 0; j--) {
+            const el = this.get_item(j)
+            if (el?.get_path() === path) this.remove(j)
+        }
         this.insert(0, Gio.File.new_for_path(path))
     }
 })

--- a/src/reader/metadata.html
+++ b/src/reader/metadata.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script type="module" src="metadata.js"></script>

--- a/src/reader/metadata.js
+++ b/src/reader/metadata.js
@@ -1,0 +1,28 @@
+import { makeBook } from '../foliate-js/view.js'
+
+const blobToBase64 = blob => new Promise(resolve => {
+    const reader = new FileReader()
+    reader.readAsDataURL(blob)
+    reader.onloadend = () => resolve(reader.result.split(',')[1])
+})
+
+const base64ToUint8Array = base64 =>
+    Uint8Array.from(atob(base64), char => char.charCodeAt(0))
+
+const makeFileFromPayload = ({ data, name, mimeType }) => {
+    if (!data) return null
+    const bytes = base64ToUint8Array(data)
+    const blob = new Blob([bytes], { type: mimeType ?? '' })
+    return new File([blob], name ?? 'book', { type: mimeType ?? '' })
+}
+
+globalThis.getMetadata = async payload => {
+    const target = makeFileFromPayload(payload) ?? payload.uri
+    if (!target) throw new Error('Missing payload data')
+    const book = await makeBook(target)
+    const cover = await book.getCover?.()
+    return {
+        metadata: book.metadata ?? {},
+        cover: cover ? await blobToBase64(cover) : null,
+    }
+}

--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -148,7 +148,7 @@
             <object class="GtkStackPage">
               <property name="name">loading</property>
               <property name="child">
-                <object class="AdwSpinner"/>
+                <object class="GtkSpinner"/>
               </property>
             </object>
           </child>
@@ -282,9 +282,9 @@
                 </object>
               </child>
               <child type="bottom">
-                <object class="AdwInlineViewSwitcher" id="contents-stack-switcher">
+                <object class="AdwViewSwitcher" id="contents-stack-switcher">
                   <property name="stack">contents-stack</property>
-                  <property name="display-mode">icons</property>
+                  <property name="policy">wide</property>
                   <property name="margin-top">6</property>
                   <property name="margin-bottom">6</property>
                   <property name="margin-start">6</property>

--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -148,7 +148,7 @@
             <object class="GtkStackPage">
               <property name="name">loading</property>
               <property name="child">
-                <object class="GtkSpinner"/>
+                <object class="AdwSpinner"/>
               </property>
             </object>
           </child>
@@ -282,9 +282,9 @@
                 </object>
               </child>
               <child type="bottom">
-                <object class="AdwViewSwitcher" id="contents-stack-switcher">
+                <object class="AdwInlineViewSwitcher" id="contents-stack-switcher">
                   <property name="stack">contents-stack</property>
-                  <property name="policy">wide</property>
+                  <property name="display-mode">icons</property>
                   <property name="margin-top">6</property>
                   <property name="margin-bottom">6</property>
                   <property name="margin-start">6</property>

--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -148,9 +148,7 @@
             <object class="GtkStackPage">
               <property name="name">loading</property>
               <property name="child">
-                <object class="GtkSpinner">
-                  <property name="spinning">true</property>
-                </object>
+                <object class="AdwSpinner"/>
               </property>
             </object>
           </child>
@@ -284,9 +282,9 @@
                 </object>
               </child>
               <child type="bottom">
-                <object class="AdwViewSwitcher" id="contents-stack-switcher">
+                <object class="AdwInlineViewSwitcher" id="contents-stack-switcher">
                   <property name="stack">contents-stack</property>
-                  <property name="policy">wide</property>
+                  <property name="display-mode">icons</property>
                   <property name="margin-top">6</property>
                   <property name="margin-bottom">6</property>
                   <property name="margin-start">6</property>

--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -148,7 +148,9 @@
             <object class="GtkStackPage">
               <property name="name">loading</property>
               <property name="child">
-                <object class="AdwSpinner"/>
+                <object class="GtkSpinner">
+                  <property name="spinning">true</property>
+                </object>
               </property>
             </object>
           </child>
@@ -282,9 +284,9 @@
                 </object>
               </child>
               <child type="bottom">
-                <object class="AdwInlineViewSwitcher" id="contents-stack-switcher">
+                <object class="AdwViewSwitcher" id="contents-stack-switcher">
                   <property name="stack">contents-stack</property>
-                  <property name="display-mode">icons</property>
+                  <property name="policy">wide</property>
                   <property name="margin-top">6</property>
                   <property name="margin-bottom">6</property>
                   <property name="margin-start">6</property>

--- a/src/ui/library.ui
+++ b/src/ui/library.ui
@@ -20,6 +20,10 @@
       <attribute name="label" translatable="yes">Open…</attribute>
       <attribute name="action">win.open</attribute>
     </item>
+    <item>
+      <attribute name="label" translatable="yes">Import Books…</attribute>
+      <attribute name="action">win.import-books</attribute>
+    </item>
   </section>
   <section>
     <item>

--- a/src/utils.js
+++ b/src/utils.js
@@ -402,3 +402,17 @@ export const addClass = (widget, ...classes) => {
     for (const c of classes) widget.add_css_class(c)
     return widget
 }
+
+export const makeIdentifier = file => {
+    try {
+        const stream = file.read(null)
+        // 10000000 might not be the best value but I guess we will stick to it
+        // for compatibility with previous versions
+        const bytes = stream.read_bytes(10000000, null)
+        const md5 = GLib.compute_checksum_for_bytes(GLib.ChecksumType.MD5, bytes)
+        return `foliate:${md5}`
+    } catch(e) {
+        console.warn(e)
+        return null
+    }
+}


### PR DESCRIPTION
This pull request introduces a new bulk import feature for e-books, allowing users to import multiple books at once from files or folders. It also includes several UI improvements and minor bug fixes to enhance stability and user experience.

**Bulk Import Feature:**

* Added a new `import-books` action to `ApplicationWindow`, enabling users to import multiple e-books via a dialog that supports both file and folder selection. This includes recursive folder scanning and feedback to the user via toast notifications. [[1]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L77-R77) [[2]](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6R176-R371)
* Registered a keyboard shortcut (`Ctrl+Shift+O`) for the new import action.
* Added an "Import Books…" menu item in the library UI, linked to the new action.

**Book Viewer and Library Stability Improvements:**

* Fixed a bug in `BookViewer` where the window title could be set when `root` was undefined, and improved cleanup logic in `vfunc_unroot`. [[1]](diffhunk://#diff-fee40a9c59d71e65bbf79ba70e28d160da0e7a6cee9e1e385594f8e0d131860cL745-R745) [[2]](diffhunk://#diff-fee40a9c59d71e65bbf79ba70e28d160da0e7a6cee9e1e385594f8e0d131860cR1007)
* In `Library`, ensured the sidebar header function is cleared during disposal to prevent callbacks after shutdown.

**UI Updates:**

* Replaced `AdwSpinner` with `GtkSpinner` and updated the contents stack switcher to use `AdwViewSwitcher` with improved policy settings in the book viewer UI. [[1]](diffhunk://#diff-6848d3db42ed6a7283fbaeb9d87ade7769fa53b8229b032b3e68b2c8df13882fL151-R151) [[2]](diffhunk://#diff-6848d3db42ed6a7283fbaeb9d87ade7769fa53b8229b032b3e68b2c8df13882fL285-R287)