### PR TITLE
feat: refine book status logic and add visual indicators

### DIFF
--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -795,6 +795,8 @@ export const BookViewer = GObject.registerClass({
             if (cover) this.#data.saveCover(cover)
         }
         else await this._view.next()
+
+        if (this.#data.status === 'pending') this.#data.status = 'reading'
     }
     #onRelocate(payload) {
         const { section, location, tocItem, cfi } = payload
@@ -806,6 +808,9 @@ export const BookViewer = GObject.registerClass({
         if (this.#data) {
             this.#data.storage.set('progress', [location.current, location.total])
             this.#data.storage.set('lastLocation', cfi)
+            if (location.current >= location.total && this.#data.status === 'reading') {
+                this.#data.status = 'completed'
+            }
         }
     }
     #deleteAnnotation(annotation) {

--- a/src/data.js
+++ b/src/data.js
@@ -99,6 +99,12 @@ class BookData {
             ? path.replace(homeDir, '~')
             : file.get_uri())
     }
+    get status() {
+        return this.storage.get('status', 'pending')
+    }
+    set status(value) {
+        this.storage.set('status', value)
+    }
 }
 
 class BookDataStore {
@@ -108,17 +114,24 @@ class BookDataStore {
     get(key, view) {
         const map = this.#map
         if (map.has(key)) {
-            this.#views.get(key).add(view)
-            this.#keys.set(view, key)
-            return map.get(key).initView(view)
+            const obj = map.get(key)
+            if (view) {
+                this.#views.get(key).add(view)
+                this.#keys.set(view, key)
+                return obj.initView(view)
+            }
+            return obj
         }
         else {
-            const views = new Set([view])
+            const views = new Set(view ? [view] : [])
             const obj = new BookData(key, views)
             map.set(key, obj)
             this.#views.set(key, views)
-            this.#keys.set(view, key)
-            return obj.initView(view, true)
+            if (view) {
+                this.#keys.set(view, key)
+                return obj.initView(view, true)
+            }
+            return obj
         }
     }
     delete(view) {

--- a/src/library.js
+++ b/src/library.js
@@ -12,6 +12,7 @@ import * as utils from './utils.js'
 import * as format from './format.js'
 import { exportAnnotations } from './annotations.js'
 import { formatLanguageMap, formatAuthors, makeBookInfoWindow } from './book-info.js'
+import { dataStore } from './data.js'
 
 import WebKit from 'gi://WebKit'
 import { WebView } from './webview.js'
@@ -224,25 +225,34 @@ const fraction = p => !isNaN(p?.[1]) && p?.[1] > 0 ? p[0] / p[1] : null
 const BookItem = GObject.registerClass({
     GTypeName: 'FoliateBookItem',
     Template: pkg.moduleuri('ui/book-item.ui'),
-    InternalChildren: ['image', 'progress', 'title'],
+    InternalChildren: ['image', 'progress', 'title', 'status'],
     Signals: {
         'open-new-window': { param_types: [Gio.File.$gtype] },
         'remove-book': { param_types: [Gio.File.$gtype] },
         'export-book': { param_types: [Gio.File.$gtype] },
         'book-info': { param_types: [Gio.File.$gtype] },
         'open-external-app': { param_types: [Gio.File.$gtype] },
+        'set-status': { param_types: [Gio.File.$gtype, GObject.TYPE_STRING] },
     },
 }, class extends Gtk.Box {
     #item
     constructor(params) {
         super(params)
-        this.insert_action_group('book-item', utils.addSimpleActions({
+        const actionGroup = utils.addSimpleActions({
             'open-new-window': () => this.emit('open-new-window', this.#item),
             'remove': () => this.emit('remove-book', this.#item),
             'export': () => this.emit('export-book', this.#item),
             'info': () => this.emit('book-info', this.#item),
             'open-external-app': () => this.emit('open-external-app', this.#item),
-        }))
+        })
+        const setStatusAction = new Gio.SimpleAction({
+            name: 'set-status',
+            parameter_type: GLib.VariantType.new('s'),
+        })
+        setStatusAction.connect('activate', (_, param) =>
+            this.emit('set-status', this.#item, param.deep_unpack()))
+        actionGroup.add_action(setStatusAction)
+        this.insert_action_group('book-item', actionGroup)
     }
     update(item, data, cover) {
         this.#item = item
@@ -250,31 +260,43 @@ const BookItem = GObject.registerClass({
         this._title.text = title
         this._image.load(cover?.then ? null : cover, title)
         this._progress.label = format.percent(fraction(data.progress))
+        const status = data.status || 'pending'
+        this._status.label = status.charAt(0).toUpperCase() + status.slice(1)
+        this._progress.visible = status !== 'completed' && status !== 'pending'
     }
 })
 
 const BookRow = GObject.registerClass({
     GTypeName: 'FoliateBookRow',
     Template: pkg.moduleuri('ui/book-row.ui'),
-    InternalChildren: ['title', 'author', 'progress-grid', 'progress-bar', 'progress-label'],
+    InternalChildren: ['title', 'author', 'progress-grid', 'progress-bar', 'progress-label', 'status'],
     Signals: {
         'open-new-window': { param_types: [Gio.File.$gtype] },
         'remove-book': { param_types: [Gio.File.$gtype] },
         'export-book': { param_types: [Gio.File.$gtype] },
         'book-info': { param_types: [Gio.File.$gtype] },
         'open-external-app': { param_types: [Gio.File.$gtype] },
+        'set-status': { param_types: [Gio.File.$gtype, GObject.TYPE_STRING] },
     },
 }, class extends Gtk.Box {
     #item
     constructor(params) {
         super(params)
-        this.insert_action_group('book-item', utils.addSimpleActions({
+        const actionGroup = utils.addSimpleActions({
             'open-new-window': () => this.emit('open-new-window', this.#item),
             'remove': () => this.emit('remove-book', this.#item),
             'export': () => this.emit('export-book', this.#item),
             'info': () => this.emit('book-info', this.#item),
             'open-external-app': () => this.emit('open-external-app', this.#item),
-        }))
+        })
+        const setStatusAction = new Gio.SimpleAction({
+            name: 'set-status',
+            parameter_type: GLib.VariantType.new('s'),
+        })
+        setStatusAction.connect('activate', (_, param) =>
+            this.emit('set-status', this.#item, param.deep_unpack()))
+        actionGroup.add_action(setStatusAction)
+        this.insert_action_group('book-item', actionGroup)
     }
     update(item, data) {
         this.#item = item
@@ -302,6 +324,9 @@ const BookRow = GObject.registerClass({
             grid.attach(this._progress_bar, 0, 0, span, 1)
             grid.attach(this._progress_label, span, 0, steps - span, 1)
         }
+        const status = data.status || 'pending'
+        this._status.label = status.charAt(0).toUpperCase() + status.slice(1)
+        this._progress_grid.visible = status !== 'completed' && status !== 'pending'
     }
 })
 
@@ -323,6 +348,8 @@ GObject.registerClass({
 }, class extends Gtk.Stack {
     #done = false
     #filter = new Gtk.CustomFilter()
+    #statusFilter = 'all'
+    #searchQuery = ''
     #filterModel = utils.connect(new Gtk.FilterListModel({ filter: this.#filter }),
         { 'items-changed': () => this.#update() })
     #itemConnections = {
@@ -339,6 +366,20 @@ GObject.registerClass({
             makeBookInfoWindow(this.get_root(), metadata, cover)
         },
         'open-external-app': (_, file) => this.openWithExternalApp(getBooks().getBook(file)),
+        'set-status': (_, file, status) => {
+            const key = decodeURIComponent(file.get_basename().replace('.json', ''))
+            const data = dataStore.get(key)
+            data.status = status
+            if (status === 'completed') {
+                const progress = data.storage.get('progress')
+                if (progress) {
+                    const total = progress[1]
+                    data.storage.set('progress', [total, total])
+                } else {
+                    data.storage.set('progress', [1, 1])
+                }
+            }
+        },
     }
     actionGroup = utils.addMethods(this, {
         props: ['view-mode'],
@@ -417,16 +458,32 @@ GObject.registerClass({
         return { cover, data }
     }
     search(text) {
-        const q = text.trim().toLowerCase()
-        if (!q) {
+        this.#searchQuery = text.trim().toLowerCase()
+        this.#updateFilterFunc()
+    }
+    setFilter(status) {
+        this.#statusFilter = status
+        this.#updateFilterFunc()
+    }
+    #updateFilterFunc() {
+        const q = this.#searchQuery
+        const status = this.#statusFilter
+
+        this.emit('load-all')
+
+        if (!q && status === 'all') {
             this.#filter.set_filter_func(null)
             return
         }
-        this.emit('load-all')
+
         const fields = ['title', 'creator', 'description']
         const { readFile } = this.#filterModel.model
         this.#filter.set_filter_func(file => {
-            const { metadata } = readFile(file)
+            const data = readFile(file)
+            if (!data) return false
+            const { metadata } = data
+            if (status !== 'all' && (data.status || 'reading') !== status) return false
+            if (!q) return true
             if (!metadata) return false
             return fields.some(field => matchString(metadata[field], q))
         })
@@ -791,7 +848,7 @@ export const Library = GObject.registerClass({
         'breakpoint-bin', 'split-view',
         'sidebar-list-box', 'main-stack',
         'library-toolbar-view', 'catalog-toolbar-view',
-        'books-view', 'search-bar', 'search-entry',
+        'books-view', 'search-bar', 'search-entry', 'filter-dropdown',
         'opds-view',
     ],
 }, class extends Gtk.Box {
@@ -906,6 +963,11 @@ export const Library = GObject.registerClass({
         this._search_bar.connect_entry(this._search_entry)
         this._search_entry.connect('search-changed', entry =>
             this._books_view.search(entry.text))
+        
+        this._filter_dropdown.connect('notify::selected-item', () => {
+            const status = this._filter_dropdown.selected_item.string.toLowerCase()
+            this._books_view.setFilter(status)
+        })
 
         this.insert_action_group('library', this._books_view.actionGroup)
         this.insert_action_group('catalog', this._opds_view.actionGroup)

--- a/src/ui/book-item.ui
+++ b/src/ui/book-item.ui
@@ -21,6 +21,26 @@
     </item>
   </section>
   <section>
+    <submenu>
+      <attribute name="label" translatable="yes">Status</attribute>
+      <section>
+        <item>
+          <attribute name="label" translatable="yes">Reading</attribute>
+          <attribute name="action">book-item.set-status</attribute>
+          <attribute name="target">reading</attribute>
+        </item>
+        <item>
+          <attribute name="label" translatable="yes">Completed</attribute>
+          <attribute name="action">book-item.set-status</attribute>
+          <attribute name="target">completed</attribute>
+        </item>
+        <item>
+          <attribute name="label" translatable="yes">Pending</attribute>
+          <attribute name="action">book-item.set-status</attribute>
+          <attribute name="target">pending</attribute>
+        </item>
+      </section>
+    </submenu>
     <item>
       <attribute name="label" translatable="yes">Remove</attribute>
       <attribute name="action">book-item.remove</attribute>
@@ -50,6 +70,13 @@
     <child>
       <object class="GtkBox">
         <child>
+          <object class="GtkLabel" id="status">
+            <property name="xalign">0</property>
+            <property name="hexpand">true</property>
+            <style><class name="caption"/><class name="dim-label"/></style>
+          </object>
+        </child>
+        <child>
           <object class="GtkLabel" id="progress">
             <property name="xalign">0</property>
             <property name="hexpand">true</property>
@@ -62,7 +89,7 @@
             <property name="visible">True</property>
             <property name="valign">center</property>
             <property name="icon-name">view-more-horizontal-symbolic</property>
-            <property name="tooltip-text" translatable="yes">Menu</property>"
+            <property name="tooltip-text" translatable="yes">Menu</property>
             <property name="menu-model">menu</property>
             <style><class name="flat"/><class name="circular"/></style>
           </object>

--- a/src/ui/book-row.ui
+++ b/src/ui/book-row.ui
@@ -21,6 +21,26 @@
     </item>
   </section>
   <section>
+    <submenu>
+      <attribute name="label" translatable="yes">Status</attribute>
+      <section>
+        <item>
+          <attribute name="label" translatable="yes">Reading</attribute>
+          <attribute name="action">book-item.set-status</attribute>
+          <attribute name="target">reading</attribute>
+        </item>
+        <item>
+          <attribute name="label" translatable="yes">Completed</attribute>
+          <attribute name="action">book-item.set-status</attribute>
+          <attribute name="target">completed</attribute>
+        </item>
+        <item>
+          <attribute name="label" translatable="yes">Pending</attribute>
+          <attribute name="action">book-item.set-status</attribute>
+          <attribute name="target">pending</attribute>
+        </item>
+      </section>
+    </submenu>
     <item>
       <attribute name="label" translatable="yes">Remove</attribute>
       <attribute name="action">book-item.remove</attribute>
@@ -54,6 +74,13 @@
           </object>
         </child>
         <child>
+          <object class="GtkLabel" id="status">
+            <property name="xalign">0</property>
+            <property name="ellipsize">end</property>
+            <style><class name="caption"/><class name="dim-label"/></style>
+          </object>
+        </child>
+        <child>
           <object class="GtkGrid" id="progress-grid">
             <property name="column-homogeneous">True</property>
             <property name="column-spacing">6</property>
@@ -76,7 +103,7 @@
     <child>
       <object class="GtkMenuButton">
         <property name="icon-name">view-more-symbolic</property>
-        <property name="tooltip-text" translatable="yes">Menu</property>"
+        <property name="tooltip-text" translatable="yes">Menu</property>
         <property name="menu-model">menu</property>
         <property name="valign">center</property>
         <style><class name="flat"/><class name="circular"/></style>

--- a/src/ui/library.ui
+++ b/src/ui/library.ui
@@ -119,6 +119,20 @@
                         </object>
                       </child>
                       <child type="end">
+                        <object class="GtkDropDown" id="filter-dropdown">
+                          <property name="model">
+                            <object class="GtkStringList">
+                              <items>
+                                <item translatable="yes">All</item>
+                                <item translatable="yes">Reading</item>
+                                <item translatable="yes">Completed</item>
+                                <item translatable="yes">Pending</item>
+                              </items>
+                            </object>
+                          </property>
+                        </object>
+                      </child>
+                      <child type="end">
                         <object class="GtkToggleButton">
                           <property name="icon-name">edit-find-symbolic</property>
                           <property name="tooltip-text" translatable="yes">Search</property>


### PR DESCRIPTION
- Change default book status to 'pending' instead of 'reading'
- Automatically switch to 'reading' when opening a 'pending' book
- Automatically switch to 'completed' when reaching the end of a book
- Set progress to 100% when manually marking a book as completed
- Add visual status labels (Pending/Completed) to Library Grid and List views
- Hide progress bar for 'pending' and 'completed' items to reduce clutter
- Fix 'set-status' action handling to correctly accept string parameters
- Fix crash in BookDataStore when accessing data without an active view
- Remove duplicate code in library.js


<img width="3418" height="1011" alt="image" src="https://github.com/user-attachments/assets/9c326bf1-07ba-482e-b50e-87f7edefe960" />
<img width="3421" height="1023" alt="image" src="https://github.com/user-attachments/assets/f733e840-c42f-4ecd-9ad8-d0147eccebef" />
