### PR TITLE
Add option for rosepine theme

### DIFF
--- a/src/themes.js
+++ b/src/themes.js
@@ -49,6 +49,11 @@ export const themes = [
         light: { fg: '#2e3440', bg: '#eceff4', link: '#5e81ac' },
         dark: { fg: '#d8dee9', bg: '#2e3440', link: '#88c0d0' },
     },
+    {
+        name: 'rosepine', label: _('Rosepine'),
+        light: { fg: '#575279', bg: '#faf4ed', link: '#907aa9' },
+        dark: { fg: '#e0def4', bg: '#232136', link: '#c4a7e7' },
+    },
 ]
 
 for (const { file, name } of utils.listDir(pkg.configpath('themes'))) try {


### PR DESCRIPTION
This pull request just adds the option for the rosepine theme.

Added Rosepine Moon (dark) and Rosepine Dawn (light) variants

I love the rosepine theme so I wanted to contribute this

Moon:
<img width="1920" height="1036" alt="foliate-rosepine-dark" src="https://github.com/user-attachments/assets/4e8ea2c5-3a77-4c40-ac6b-8f3c017a53fd" />

Dawn:
<img width="1920" height="1036" alt="foliate-rosepine-light" src="https://github.com/user-attachments/assets/d41598a6-09d6-4288-99f1-fb22b38de2da" />
