### PR TITLE
Local opds library files

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -564,7 +564,7 @@ GObject.registerClass({
                     this.#state = payload.state
                     this.actionGroup.lookup_action('search').enabled =
                         !!this.#state?.search && !!this.#state?.searchEnabled
-                    this.emit('state-changed', this.#state)
+                    this.emit('state-changed', this.#state ?? null)
                     break
             }
         })
@@ -601,6 +601,11 @@ GObject.registerClass({
     }
     download({ href, token }) {
         const webView = this.child
+        if (href.startsWith('file://')) {
+            webView.exec('finishDownload', { token })
+            this.root.openFile(Gio.File.new_for_uri(href))
+            return
+        }
         new Promise((resolve, reject) => {
             let file
             const download = utils.connect(webView.download_uri(href), {

--- a/src/opds/main.html
+++ b/src/opds/main.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="color-scheme" content="light dark">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src foliate-opds:; style-src 'unsafe-inline'; img-src *; connect-src *; frame-src 'self';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src foliate-opds:; style-src 'unsafe-inline'; img-src * file:; connect-src * file: foliate-opds:; frame-src 'self';">
 <style>
 :not(:defined) > * {
     display: none;

--- a/src/opds/main.js
+++ b/src/opds/main.js
@@ -33,6 +33,11 @@ const filterKeys = (map, f) => Array.from(map, ([key, val]) =>
 const resolveURL = (url, relativeTo) => {
     if (!url) return ''
     try {
+        if (relativeTo.startsWith('file://') && url.startsWith('/')) {
+            // Catalog uses server-style absolute paths; resolve relative to catalog's directory
+            const dir = relativeTo.slice(0, relativeTo.lastIndexOf('/') + 1)
+            return dir + encodeURI(url.slice(1))
+        }
         if (relativeTo.includes(':')) return new URL(url, relativeTo).toString()
         // the base needs to be a valid URL, so set a base URL and then remove it
         const root = 'https://invalid.invalid/'
@@ -633,9 +638,13 @@ document.querySelector('#search button').textContent = globalThis.uiText.search
 
 try {
     const params = new URLSearchParams(location.search)
-    const res = await fetch(params.get('url'))
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-    const url = res.url
+    const rawURL = params.get('url')
+    const fetchURL = rawURL.startsWith('file://')
+        ? `foliate-opds:///local-file${new URL(rawURL).pathname}`
+        : rawURL
+    const res = await fetch(fetchURL)
+    if (!res.ok && res.status !== 0) throw new Error(`${res.status} ${res.statusText}`)
+    const url = rawURL.startsWith('file://') ? rawURL : res.url
     const text = await res.text()
     if (text.startsWith('<')) {
         const doc = new DOMParser().parseFromString(text, MIME.XML)

--- a/src/webview.js
+++ b/src/webview.js
@@ -26,7 +26,24 @@ const registerPaths = (name, dirs) => registerScheme(name, req => {
 })
 
 registerPaths('foliate', ['/reader/', '/foliate-js/'])
-registerPaths('foliate-opds', ['/opds/', '/foliate-js/', '/icons/', '/common/'])
+registerScheme('foliate-opds', req => {
+    let path = pkg.MESON
+        ? req.get_path().replace(/(?<=\/icons)\/hicolor(?=\/scalable\/)/, '')
+        : req.get_path()
+
+    if (path.startsWith('/local-file/')) {
+        const file = Gio.File.new_for_path(path.slice('/local-file'.length))
+        req.finish(file.read(null), -1, 'application/octet-stream')
+        return
+    }
+
+    const dirs = ['/opds/', '/foliate-js/', '/icons/', '/common/']
+    if (dirs.every(dir => !path.startsWith(dir))) throw new Error()
+    const mime = path.endsWith('.js') || path.endsWith('.mjs') ? 'application/javascript'
+        : path.endsWith('.svg') ? 'image/svg+xml' : 'text/html'
+    const file = Gio.File.new_for_uri(pkg.moduleuri(path))
+    req.finish(file.read(null), -1, mime)
+})
 registerPaths('foliate-selection-tool', ['/selection-tools/', '/icons/', '/common/'])
 
 /*


### PR DESCRIPTION
Smallish change to allow specifying an opds file with a `file://` path, which supports my workflow and might be useful to other people too.

Works on linux (tested with gtk4 branch running with `gjs -m src/main.js` on Manjaro), not tested elsewhere but I don't see a reason why it'd fail.

I'm generating the local opds file I'm using from this project: https://git.mutual.email/john/opdsdir

