### PR TITLE
fix: correct typo in Portuguese translation of empty notes message

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -101,7 +101,7 @@ msgstr "Ocorreu um erro"
 
 #: src/annotations.js:635
 msgid "You don’t have any annotations for this book"
-msgstr "Você não tem anotações parra este livro"
+msgstr "Você não tem anotações para este livro"
 
 #: src/annotations.js:648
 #, javascript-format


### PR DESCRIPTION
This PR fixes a small typo in the Portuguese (pt_BR) translation file (pt_BR.po).

In line 104, the word "parra" was incorrectly typed. It has been corrected to "para" in the string: "Você não tem anotações para esse livro".