### PR TITLE
Add option to disable selection popup

### DIFF
--- a/data/com.github.johnfactotum.Foliate.gschema.xml
+++ b/data/com.github.johnfactotum.Foliate.gschema.xml
@@ -51,6 +51,9 @@
     <key name="translate-target-language" type="s">
         <default>''</default>
     </key>
+    <key name="selection-popup" type="b">
+      <default>true</default>
+    </key>
   </schema>
 
   <schema id="com.github.johnfactotum.Foliate.viewer.view"

--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -507,6 +507,7 @@ export const BookViewer = GObject.registerClass({
     Properties: utils.makeParams({
         'fold-sidebar': 'boolean',
         'highlight-color': 'string',
+        'selection-popup': 'boolean',
     }),
     InternalChildren: [
         'top-overlay-box', 'top-overlay-stack',
@@ -550,7 +551,8 @@ export const BookViewer = GObject.registerClass({
             },
         })
         this.highlight_color = 'yellow'
-        utils.bindSettings('viewer', this, ['fold-sidebar', 'highlight-color'])
+        this.selection_popup = true
+        utils.bindSettings('viewer', this, ['fold-sidebar', 'highlight-color', 'selection-popup'])
         this._view.fontSettings.bindSettings('viewer.font')
         this._view.viewSettings.bindSettings('viewer.view')
         this._view.webView.connect('notify::zoom-level', webView =>
@@ -739,7 +741,7 @@ export const BookViewer = GObject.registerClass({
                 'preferences', 'help-overlay', 'show-info', 'bookmark',
                 'export-annotations', 'import-annotations',
             ],
-            props: ['fold-sidebar'],
+            props: ['fold-sidebar', 'selection-popup'],
         })
         utils.addPropertyActions(Adw.StyleManager.get_default(), ['color-scheme'], actions)
         this.insert_action_group('view', this._view.actionGroup)
@@ -874,6 +876,7 @@ export const BookViewer = GObject.registerClass({
             this.#data.addAnnotation(annotation) }))
     }
     #showSelection({ type, value, text, content, lang, pos: { point, dir } }) {
+        if (type !== 'annotation' && !this.selection_popup) return Promise.resolve()
         if (type === 'annotation') return new Promise(resolve => {
             this._annotation_view.scrollToCFI(value)
             const annotation = this.#data.annotations.get(value)

--- a/src/ui/book-viewer.ui
+++ b/src/ui/book-viewer.ui
@@ -95,6 +95,10 @@
       <attribute name="label" translatable="yes">Autohide Cursor</attribute>
       <attribute name="action">view.autohide-cursor</attribute>
     </item>
+    <item>
+      <attribute name="label" translatable="yes">Show Selection Popup</attribute>
+      <attribute name="action">viewer.selection-popup</attribute>
+    </item>
   </section>
   <section>
     <item>


### PR DESCRIPTION
## Summary

- Add `selection-popup` boolean key to `com.github.johnfactotum.Foliate.viewer` schema (default: `true`)
- Expose it as a toggle in the book menu alongside "Autohide Cursor"
- When disabled, selecting text no longer shows the popup toolbar; annotation popovers for existing highlights are unaffected

## Toggle via UI

Book menu → "Show Selection Popup"

## Toggle via command line

\`\`\`
gsettings set com.github.johnfactotum.Foliate.viewer selection-popup false
\`\`\`