### PR TITLE
Wire up TTS voice selection dropdown in Narration popover

### DIFF
--- a/src/navbar.js
+++ b/src/navbar.js
@@ -173,6 +173,13 @@ GObject.registerClass({
             actions: ['copy-cfi', 'paste-cfi', 'toggle-landmarks'],
         })
         this.insert_action_group('navbar', actions)
+
+        // Lazy-populate the TTS voice dropdown the first time the Narration
+        // popover is shown. This keeps SSIP and speech-dispatcher from
+        // being initialized at application startup for users who never
+        // use TTS.
+        this._tts_popover.connect('show', () =>
+            this.tts_box.loadVoices?.().catch(e => console.error(e)))
     }
     get shouldStayVisible() {
         return this._location_popover.visible || this._tts_popover.visible

--- a/src/speech.js
+++ b/src/speech.js
@@ -151,6 +151,9 @@ export class SSIPClient {
     setPitch(rate) {
         return this.send(`SET self PITCH ${rate}`)
     }
+    setVoice(name) {
+        return this.send(`SET self SYNTHESIS_VOICE ${name}`)
+    }
     async listSynthesisVoices() {
         const data = await this.send('LIST SYNTHESIS_VOICES')
         return data.map(row => {

--- a/src/tts.js
+++ b/src/tts.js
@@ -25,11 +25,13 @@ GObject.registerClass({
         'next-section': { return_type: GObject.TYPE_JSOBJECT },
     },
     InternalChildren: [
-        'tts-rate-scale', 'tts-pitch-scale',
+        'tts-rate-scale', 'tts-pitch-scale', 'tts-voice-dropdown',
         'media-buttons', 'play-button',
     ],
 }, class extends Gtk.Box {
     #state = 'stopped'
+    #voices = []
+    #suppressVoiceNotify = false
     defaultWidget = this._play_button
     constructor(params) {
         super(params)
@@ -40,6 +42,35 @@ GObject.registerClass({
 
         this.#connectScale(this._tts_rate_scale, ssip.setRate.bind(ssip))
         this.#connectScale(this._tts_pitch_scale, ssip.setPitch.bind(ssip))
+
+        // Voice selection: the dropdown is populated lazily via loadVoices()
+        // when the Narration popover is first shown, so SSIP is not
+        // initialized at application startup for users who never use TTS.
+        this._tts_voice_dropdown.connect('notify::selected', dropdown => {
+            if (this.#suppressVoiceNotify) return
+            const voice = this.#voices[dropdown.selected]
+            if (!voice) return
+            const shouldResume = this.state === 'playing'
+            this.state = 'paused'
+            ssip.stop()
+                .then(() => ssip.setVoice(voice.name))
+                .then(() => shouldResume ? this.start() : null)
+                .catch(e => this.error(e))
+        })
+    }
+    // Populate the voice dropdown from the synthesis voices registered in
+    // Speech Dispatcher. Idempotent and safe to call multiple times.
+    async loadVoices() {
+        if (this.#voices.length) return
+        const voices = await ssip.listSynthesisVoices()
+        if (!voices?.length) return
+        this.#voices = voices
+        const list = new Gtk.StringList()
+        for (const { name, lang } of voices)
+            list.append(lang ? `${name} (${lang})` : name)
+        this.#suppressVoiceNotify = true
+        this._tts_voice_dropdown.model = list
+        this.#suppressVoiceNotify = false
     }
     #connectScale(scale, f) {
         scale.connect('value-changed', scale => {

--- a/src/ui/tts-box.ui
+++ b/src/ui/tts-box.ui
@@ -8,7 +8,6 @@
       <property name="column-spacing">6</property>
       <property name="row-spacing">9</property>
       <property name="margin-start">6</property>
-      <!--
       <child>
         <object class="GtkLabel">
           <property name="label" translatable="yes">Voice</property>
@@ -22,13 +21,13 @@
       <child>
         <object class="GtkDropDown" id="tts-voice-dropdown">
           <property name="hexpand">True</property>
+          <property name="width-request">200</property>
           <layout>
             <property name="row">0</property>
             <property name="column">1</property>
           </layout>
         </object>
       </child>
-      -->
       <child>
         <object class="GtkLabel">
           <property name="label" translatable="yes">Speed</property>


### PR DESCRIPTION
## Summary

Completes the commented-out voice dropdown stub that has been sitting in `src/ui/tts-box.ui` for some time, by:

1. Adding `SSIPClient.setVoice(name)` in `src/speech.js` (one-line method, mirrors the existing `setRate` / `setPitch` pattern).
2. Uncommenting the `GtkDropDown` and its label in `src/ui/tts-box.ui`.
3. Wiring selection, population, and notify-suppression in `src/tts.js` on `FoliateTTSBox`.
4. Triggering a lazy `loadVoices()` call from `src/navbar.js` when the Narration popover is first shown.

## Design notes

- **Lazy loading.** The dropdown is populated on popover `show`, not in the widget constructor. This preserves the current behavior where Speech Dispatcher is only spawned when the user explicitly uses TTS — users who never click the Narration button never incur an SSIP init.
- **No new toolbar widgets.** The dropdown sits inside the existing popover next to Speed and Pitch. The toolbar surface is unchanged.
- **Entries labeled `<name> (<lang>)`** when `LIST SYNTHESIS_VOICES` reports a language, otherwise just `<name>`. Labels are derived from whatever the active output module returns, so the experience scales to whichever TTS backend the user has configured (espeak-ng, piper, mimic3, mary, etc.).
- **Resume semantics match the sliders.** Changing voice mid-playback briefly stops SSIP, applies the new voice, and resumes from the same position — the same pattern used by `#connectScale` for Rate/Pitch.
- **Suppression flag.** Setting the dropdown `model` fires a `notify::selected` signal that would otherwise trigger `setVoice` on the default voice the first time the popover opens, unnecessarily interrupting any already-running speech. A small `#suppressVoiceNotify` flag guards against that.

## Why this complements existing work

The commented-out stub at `src/ui/tts-box.ui` suggests the dropdown was always intended but not finished. This PR finishes it with the minimum amount of new code (~40 lines) and does not introduce any new dependencies. It also removes a commented-out block, which the `CONTRIBUTING.md` explicitly calls out as something to avoid in PRs.

## Test plan

- [x] Built locally against Foliate 3.1.1 (Ubuntu 24.04 system libraries).
- [x] Verified the dropdown is empty until the Narration popover is first opened — SSIP is not spawned at startup.
- [x] Verified the dropdown populates with voices reported by the active Speech Dispatcher module.
- [x] Verified selecting a different voice while playing pauses, applies the voice, and resumes from the same position.
- [x] Verified no spurious `setVoice` is fired on initial model population.
- [x] Verified that if `listSynthesisVoices` returns an empty list, the dropdown stays empty and no error dialog is shown.

Tested with four Piper voice models (en_US and en_GB, female and male) routed through a custom Speech Dispatcher generic module, as well as the default espeak-ng module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)