### PR TITLE
Add persistent play/pause button to navbar for TTS

### DIFF
--- a/src/navbar.js
+++ b/src/navbar.js
@@ -125,6 +125,7 @@ GObject.registerClass({
         'prev-image', 'next-image', 'back-image', 'forward-image',
         'progress-box', 'progress-scale', 'location-button',
         'location-popover', 'tts-popover', 'tts-stack',
+        'tts-quick-play',
         'time-book', 'time-section',
         'page-label', 'page-box', 'page-drop-down', 'page-total',
         'loc-entry', 'loc-total', 'cfi-entry',
@@ -173,6 +174,19 @@ GObject.registerClass({
             actions: ['copy-cfi', 'paste-cfi', 'toggle-landmarks'],
         })
         this.insert_action_group('navbar', actions)
+
+        // Quick play/pause button: lets the user pause or resume TTS
+        // without having to re-open the Narration popover. Clicking
+        // delegates to the same play() method as the button inside the
+        // popover, and the icon-name is kept in sync via a GObject
+        // property binding so both buttons always show the same state.
+        this._tts_quick_play.connect('clicked', () => this.tts_box.play())
+        this.tts_box.playButton.bind_property(
+            'icon-name',
+            this._tts_quick_play,
+            'icon-name',
+            GObject.BindingFlags.SYNC_CREATE,
+        )
     }
     get shouldStayVisible() {
         return this._location_popover.visible || this._tts_popover.visible

--- a/src/tts.js
+++ b/src/tts.js
@@ -54,6 +54,11 @@ GObject.registerClass({
     get state() {
         return this.#state
     }
+    // Public accessor so the navbar's quick play/pause button can mirror
+    // the popover play button's icon-name via GObject property binding.
+    get playButton() {
+        return this._play_button
+    }
     set state(state) {
         this.#state = state
         this._play_button.icon_name = state === 'playing'

--- a/src/ui/navbar.ui
+++ b/src/ui/navbar.ui
@@ -84,6 +84,14 @@
     </object>
   </child>
   <child>
+    <object class="GtkButton" id="tts-quick-play">
+      <property name="valign">center</property>
+      <property name="tooltip-text" translatable="yes">Play/Pause Narration</property>
+      <property name="icon-name">media-playback-start-symbolic</property>
+      <style><class name="image-button"/></style>
+    </object>
+  </child>
+  <child>
     <object class="GtkMenuButton">
       <property name="valign">center</property>
       <property name="direction">up</property>


### PR DESCRIPTION
## Summary

Adds a small GtkButton to the main navbar, directly before the existing headphones (Narration) GtkMenuButton, that lets the user start/pause/resume TTS without having to re-open the popover each time.

## Motivation

Today, starting narration looks like this:

1. Click the headphones button → popover opens.
2. Click Play inside the popover → TTS starts.
3. Click the reading surface → popover closes (popovers autohide on outside click).
4. User now has no visible pause control.
5. To pause: click headphones again → popover → click Play (which is a toggle) → click away.

For a "read along while TTS narrates" flow, this is three round-trips just to toggle pause. Adding a persistent button in the toolbar makes it a single click.

## How it works

- **New widget**: a `GtkButton` with id `tts-quick-play`, `image-button` style, `media-playback-start-symbolic` initial icon, and tooltip "Play/Pause Narration". Placed as a sibling of the existing headphones `GtkMenuButton`.
- **Click handler**: `this._tts_quick_play.connect('clicked', () => this.tts_box.play())` — delegates to the same `play()` method that the in-popover button calls.
- **Icon sync**: a GObject property binding (`bind_property('icon-name', ..., SYNC_CREATE)`) mirrors the popover play button's `icon-name` onto the navbar button. Whichever button the user clicks, both icons flip in lockstep between `media-playback-start-symbolic` and `media-playback-pause-symbolic`.
- **One small addition to `FoliateTTSBox`**: a public `playButton` getter, so `navbar.js` can reference the internal child without reaching into private state.

## Non-goals

- **No keyboard shortcut.** A `Space` or `Ctrl+P` binding would be nice but is orthogonal and deserves its own discussion for conflict handling with the reader's existing shortcuts.
- **No change to the popover.** The popover's play button, Speed, and Pitch controls are untouched.
- **No change to FoliateMediaOverlayBox.** This PR only wires the standard TTS path.

## Visual impact

One additional button in the toolbar, same size as the other image buttons, so the toolbar widens by roughly one icon's worth. Icon and tooltip are standard GTK symbolic.

## Test plan

- [x] Built locally against Foliate 3.1.1 (Ubuntu 24.04 system libraries).
- [x] Clicked the navbar button with no prior playback → TTS starts.
- [x] Clicked the navbar button while playing → TTS pauses, icon flips to `media-playback-start-symbolic`.
- [x] Clicked the in-popover Play button while paused → TTS resumes, navbar button's icon flips to `media-playback-pause-symbolic`.
- [x] Verified the icon binding survives multiple play/pause cycles.
- [x] Verified no regression in the existing popover controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)