### PR TITLE
Fix overlay crash when opening dictionaries/wikipedia

### DIFF
--- a/src/book-viewer.js
+++ b/src/book-viewer.js
@@ -361,8 +361,13 @@ GObject.registerClass({
     }
     showPopover(popover, point, dir) {
         this.add_overlay(popover)
-        popover.connect('closed', () => utils.wait(0).then(() => {
-            this.remove_overlay(popover)
+        let handlerId = popover.connect('closed', () => utils.wait(0).then(() => {
+            if (handlerId) {
+                popover.disconnect(handlerId)
+                handlerId = null
+            }
+            if (popover.get_parent() === this)
+                this.remove_overlay(popover)
             this.deselect()
         }))
         popover.position = dir === 'up' ? Gtk.PositionType.TOP : Gtk.PositionType.BOTTOM


### PR DESCRIPTION
Fixes #1521.

This PR prevents Gjs/Gtk crashes when opening selection lookups (dictionary, wikipedia, translation).

It disconnects the 'closed' signal handler on its first invocation to avoid duplicate remove_overlay calls on the shared/memoized SelectionToolPopover, and adds a safety check to ensure we only remove the popover if it is still a child of the overlay.