### PR TITLE
Fix <pre> tag hiding blocks of text across pages

### DIFF
--- a/src/reader/reader.js
+++ b/src/reader/reader.js
@@ -105,8 +105,9 @@ const getCSS = ({
     h1, h2, h3, h4, h5, h6, hgroup, th {
         text-wrap: balance;
     }
-    pre {
+    pre, pre * {
         white-space: pre-wrap !important;
+        overflow-x: visible !important;
         tab-size: 2;
     }
 `, `


### PR DESCRIPTION
Some books have formatted blocks who have 'overflow-x: auto', but this lead to the content being hidden if it's displayed over multiple pages

Solve issue #1624